### PR TITLE
iOS のデバッグ・ビルドを追加

### DIFF
--- a/build.ios.sh
+++ b/build.ios.sh
@@ -39,7 +39,13 @@ done
 
 pushd $SOURCE_DIR/webrtc/src
   for build_config in $TARGET_BUILD_CONFIGS; do
-    build_config = "release" && (_is_debug="false"; true) || _is_debug="true"
+
+    if [ $build_config = "release" ]; then
+      _is_debug="false"
+    else
+      _is_debug="true"
+    fi
+
     ./tools_webrtc/ios/build_ios_libs.sh -o $BUILD_DIR/webrtc/$build_config --build_config $build_config --arch $TARGET_ARCHS --bitcode --extra-gn-args " \
       rtc_libvpx_build_vp9=true \
       rtc_include_tests=false \
@@ -74,7 +80,13 @@ pushd $SOURCE_DIR/webrtc/src
   for build_config in $TARGET_BUILD_CONFIGS; do
     _libs=""
     _dirs=""
-    build_config = "release" && (_is_debug="false"; true) || _is_debug="true"
+
+    if [ $build_config = "release" ]; then
+      _is_debug="false"
+    else
+      _is_debug="true"
+    fi
+
     for arch in $TARGET_ARCHS; do
       gn gen $BUILD_DIR/webrtc/$build_config/${arch}_libs --args="
         target_os=\"ios\"

--- a/build.ios.sh
+++ b/build.ios.sh
@@ -14,6 +14,7 @@ set -ex
 # ======= ここまでは全ての build.*.sh で共通（PACKAGE_NAME だけ変える）
 
 TARGET_ARCHS="arm64 x64"
+TARGET_BUILD_CONFIGS="debug release"
 
 ./scripts/get_depot_tools.sh $SOURCE_DIR
 export PATH="$SOURCE_DIR/depot_tools:$PATH"
@@ -32,21 +33,28 @@ pushd $SOURCE_DIR/webrtc/src
   patch -p1 < $SCRIPT_DIR/patches/ios_manual_audio_input.patch
 popd
 
-pushd $SOURCE_DIR/webrtc/src
-  ./tools_webrtc/ios/build_ios_libs.sh -o $BUILD_DIR/webrtc --build_config release --arch $TARGET_ARCHS --bitcode --extra-gn-args " \
-    rtc_libvpx_build_vp9=true \
-    rtc_include_tests=false \
-    rtc_build_examples=false \
-    rtc_use_h264=false \
-    use_rtti=true \
-    libcxx_abi_unstable=false \
-  "
-  _branch="M`echo $WEBRTC_VERSION | cut -d'.' -f1`"
-  _commit="`echo $WEBRTC_VERSION | cut -d'.' -f3`"
-  _revision=$WEBRTC_COMMIT
-  _maint="`echo $WEBRTC_BUILD_VERSION | cut -d'.' -f4`"
+for build_config in $TARGET_BUILD_CONFIGS; do
+  mkdir -p $BUILD_DIR/$build_config
+done
 
-cat <<EOF > $BUILD_DIR/webrtc/WebRTC.framework/build_info.json
+pushd $SOURCE_DIR/webrtc/src
+  for build_config in $TARGET_BUILD_CONFIGS; do
+    build_config = "release" && (_is_debug="false"; true) || _is_debug="true"
+    ./tools_webrtc/ios/build_ios_libs.sh -o $BUILD_DIR/webrtc/$build_config --build_config $build_config --arch $TARGET_ARCHS --bitcode --extra-gn-args " \
+      rtc_libvpx_build_vp9=true \
+      rtc_include_tests=false \
+      rtc_build_examples=false \
+      rtc_use_h264=false \
+      use_rtti=true \
+      libcxx_abi_unstable=false \
+      enable_dsyms=$_is_debug \
+    "
+    _branch="M`echo $WEBRTC_VERSION | cut -d'.' -f1`"
+    _commit="`echo $WEBRTC_VERSION | cut -d'.' -f3`"
+    _revision=$WEBRTC_COMMIT
+    _maint="`echo $WEBRTC_BUILD_VERSION | cut -d'.' -f4`"
+
+    cat <<EOF > $BUILD_DIR/webrtc/$build_config/WebRTC.framework/build_info.json
 {
     "webrtc_version": "$_branch",
     "webrtc_commit": "$_commit",
@@ -54,6 +62,7 @@ cat <<EOF > $BUILD_DIR/webrtc/WebRTC.framework/build_info.json
     "webrtc_revision": "$_revision"
 }
 EOF
+  done
 
 popd
 
@@ -62,42 +71,45 @@ pushd $SOURCE_DIR/webrtc/src
     IOS_DEPLOYMENT_TARGET=`python -c 'from build_ios_libs import IOS_DEPLOYMENT_TARGET; print(IOS_DEPLOYMENT_TARGET)'`
   popd
 
-  _libs=""
-  _dirs=""
-  for arch in $TARGET_ARCHS; do
-    gn gen $BUILD_DIR/webrtc/${arch}_libs --args="
-      target_os=\"ios\"
-      target_cpu=\"$arch\"
-      ios_enable_code_signing=false
-      use_xcode_clang=true
-      is_component_build=false
-      ios_deployment_target=\"$IOS_DEPLOYMENT_TARGET\"
-      rtc_libvpx_build_vp9=true
-      enable_ios_bitcode=true
+  for build_config in $TARGET_BUILD_CONFIGS; do
+    _libs=""
+    _dirs=""
+    build_config = "release" && (_is_debug="false"; true) || _is_debug="true"
+    for arch in $TARGET_ARCHS; do
+      gn gen $BUILD_DIR/webrtc/$build_config/${arch}_libs --args="
+        target_os=\"ios\"
+        target_cpu=\"$arch\"
+        ios_enable_code_signing=false
+        use_xcode_clang=true
+        is_component_build=false
+        ios_deployment_target=\"$IOS_DEPLOYMENT_TARGET\"
+        rtc_libvpx_build_vp9=true
+        enable_ios_bitcode=true
 
-      is_debug=false
-      rtc_include_tests=false
-      rtc_build_examples=false
-      rtc_use_h264=false
-      use_rtti=true
-      libcxx_abi_unstable=false
-    "
-    ninja -C $BUILD_DIR/webrtc/${arch}_libs
-    ninja -C $BUILD_DIR/webrtc/${arch}_libs \
-      builtin_audio_decoder_factory \
-      default_task_queue_factory \
-      native_api \
-      default_codec_factory_objc \
-      peerconnection \
-      videocapture_objc \
-      framework_objc
-    pushd $BUILD_DIR/webrtc/${arch}_libs/obj
-      /usr/bin/ar -rc $BUILD_DIR/webrtc/${arch}_libs/libwebrtc.a `find . -name '*.o'`
-      _libs="$_libs $BUILD_DIR/webrtc/${arch}_libs/libwebrtc.a"
-    popd
-    _dirs="$_dirs $BUILD_DIR/webrtc/${arch}_libs"
+        is_debug=$_is_debug
+        rtc_include_tests=false
+        rtc_build_examples=false
+        rtc_use_h264=false
+        use_rtti=true
+        libcxx_abi_unstable=false
+      "
+      ninja -C $BUILD_DIR/webrtc/$build_config/${arch}_libs
+      ninja -C $BUILD_DIR/webrtc/$build_config/${arch}_libs \
+        builtin_audio_decoder_factory \
+        default_task_queue_factory \
+        native_api \
+        default_codec_factory_objc \
+        peerconnection \
+        videocapture_objc \
+        framework_objc
+      pushd $BUILD_DIR/webrtc/$build_config/${arch}_libs/obj
+        /usr/bin/ar -rc $BUILD_DIR/webrtc/$build_config/${arch}_libs/libwebrtc.a `find . -name '*.o'`
+        _libs="$_libs $BUILD_DIR/webrtc/$build_config/${arch}_libs/libwebrtc.a"
+      popd
+      _dirs="$_dirs $BUILD_DIR/webrtc/$build_config/${arch}_libs"
+    done
+    lipo $_libs -create -output $BUILD_DIR/webrtc/$build_config/libwebrtc.a
   done
-  lipo $_libs -create -output $BUILD_DIR/webrtc/libwebrtc.a
   python tools_webrtc/libs/generate_licenses.py --target //sdk:framework_objc $BUILD_DIR/webrtc/ $_dirs
 popd
 

--- a/scripts/package_webrtc_ios.sh
+++ b/scripts/package_webrtc_ios.sh
@@ -15,18 +15,23 @@ VERSION_FILE=$5
 shift 5
 
 rm -rf $BUILD_DIR/package/webrtc
-mkdir -p $BUILD_DIR/package/webrtc/lib
+mkdir -p $BUILD_DIR/package/webrtc/debug/lib
+mkdir -p $BUILD_DIR/package/webrtc/release/lib
 mkdir -p $BUILD_DIR/package/webrtc/include
 
 # webrtc のヘッダ類
 rsync -amv '--include=*/' '--include=*.h' '--include=*.hpp' '--exclude=*' $SOURCE_DIR/webrtc/src/. $BUILD_DIR/package/webrtc/include/.
 
 # libwebrtc.a
-cp $BUILD_DIR/webrtc/libwebrtc.a $BUILD_DIR/package/webrtc/lib/
+cp $BUILD_DIR/webrtc/debug/libwebrtc.a $BUILD_DIR/package/webrtc/debug/lib/
+cp $BUILD_DIR/webrtc/release/libwebrtc.a $BUILD_DIR/package/webrtc/release/lib/
 # NOTICE
 cp $BUILD_DIR/webrtc/LICENSE.md "$BUILD_DIR/package/webrtc/NOTICE"
 # WebRTC.framework
-cp -r $BUILD_DIR/webrtc/WebRTC.framework "$BUILD_DIR/package/webrtc/WebRTC.framework"
+cp -r $BUILD_DIR/webrtc/debug/WebRTC.framework "$BUILD_DIR/package/webrtc/debug/WebRTC.framework"
+cp -r $BUILD_DIR/webrtc/release/WebRTC.framework "$BUILD_DIR/package/webrtc/release/WebRTC.framework"
+# WebRTC.dSYM ... debugのみ
+cp -r $BUILD_DIR/webrtc/debug/WebRTC.dSYM "$BUILD_DIR/package/webrtc/debug/WebRTC.dSYM"
 
 # 各種情報を拾ってくる
 cp $VERSION_FILE $BUILD_DIR/package/webrtc/VERSIONS


### PR DESCRIPTION
## 変更内容

- iOS のデバッグ・ビルドを追加しました
  - 変更後のディレクトリは以下のような構成になっています

```
$ tree -L 3 --filelimit 10
.
├── NOTICE
├── VERSIONS
├── debug
│   ├── WebRTC.dSYM
│   │   └── Contents
│   ├── WebRTC.framework
│   │   ├── Headers
│   │   ├── Info.plist
│   │   ├── LICENSE.md
│   │   ├── Modules
│   │   ├── WebRTC
│   │   └── build_info.json
│   └── lib
│       └── libwebrtc.a
├── include [25 entries exceeds filelimit, not opening dir]
└── release
    ├── WebRTC.framework
    │   ├── Headers
    │   ├── Info.plist
    │   ├── LICENSE.md
    │   ├── Modules
    │   ├── WebRTC
    │   └── build_info.json
    └── lib
        └── libwebrtc.a

13 directories, 12 files
```