### PR TITLE
アーカイブ対象のディレクトリをobj配下に修正

### DIFF
--- a/build.macos_x86_64.sh
+++ b/build.macos_x86_64.sh
@@ -90,7 +90,9 @@ EOF
     /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $_version_number" $_info_plist_path
     plutil -convert binary1 $_info_plist_path
 
-    /usr/bin/ar -rc $_libs_dir/libwebrtc.a `find . -name '*.o'`
+    pushd $_libs_dir/obj
+      /usr/bin/ar -rc $_libs_dir/libwebrtc.a `find . -name '*.o'`
+    popd
 
     python2 tools_webrtc/libs/generate_licenses.py --target //sdk:mac_framework_objc $_libs_dir/WebRTC.framework/Resources $_libs_dir
   done


### PR DESCRIPTION
- mac x86_64 の `libwebrtc.a` に含まれるファイルを修正

#12 の対応にてデバッグ/リリースビルドへ対応を致しましたが、その際 ar コマンドでアーカイブするディレクトリを誤って変更してしまっていました。今回、コマンドの実行ディレクトリを元に戻しています。



