### PR TITLE
macOS(arm64)むけのObjCヘッダー込みのWebRTC.frameworkを作成

### DIFF
--- a/build.macos_arm64.sh
+++ b/build.macos_arm64.sh
@@ -13,6 +13,8 @@ set -ex
 
 # ======= ここまでは全ての build.*.sh で共通（PACKAGE_NAME だけ変える）
 
+TARGET_BUILD_CONFIGS="debug release"
+
 ./scripts/get_depot_tools.sh $SOURCE_DIR
 export PATH="$SOURCE_DIR/depot_tools:$PATH"
 
@@ -27,35 +29,71 @@ pushd $SOURCE_DIR/webrtc/src
 popd
 
 pushd $SOURCE_DIR/webrtc/src
-  gn gen $BUILD_DIR/webrtc --args='
-    target_os="mac"
-    target_cpu="arm64"
-    is_debug=false
-    enable_dsyms=false
-    enable_stripping=true
-    rtc_include_tests=false
-    rtc_build_examples=false
-    rtc_use_h264=false
-    rtc_enable_symbol_export=true
-    is_component_build=false
-    use_rtti=true
-    libcxx_abi_unstable=false
-  '
-  ninja -C $BUILD_DIR/webrtc
-  ninja -C $BUILD_DIR/webrtc \
-    builtin_audio_decoder_factory \
-    default_task_queue_factory \
-    native_api \
-    default_codec_factory_objc \
-    peerconnection \
-    videocapture_objc \
-    mac_framework_objc
+  for _build_config in $TARGET_BUILD_CONFIGS; do
+    _libs_dir=$BUILD_DIR/webrtc/$_build_config
 
-  python2 tools_webrtc/libs/generate_licenses.py --target //sdk:mac_framework_objc $BUILD_DIR/webrtc/ $BUILD_DIR/webrtc/
+    mkdir -p $_libs_dir
+
+    if [ $_build_config = "release" ]; then
+      _is_debug="false"
+      _enable_dsyms="false"
+    else
+      _is_debug="true"
+      _enable_dsyms="true"
+    fi
+
+
+    gn gen $_libs_dir --args="
+      target_os=\"mac\"
+      target_cpu=\"arm64\"
+      enable_stripping=true
+      enable_dsyms=$_enable_dsyms
+      is_debug=$_is_debug
+      rtc_include_tests=false
+      rtc_build_examples=false
+      rtc_use_h264=false
+      rtc_enable_symbol_export=true
+      is_component_build=false
+      use_rtti=true
+      libcxx_abi_unstable=false
+    "
+    ninja -C $_libs_dir
+    ninja -C $_libs_dir \
+      builtin_audio_decoder_factory \
+      default_task_queue_factory \
+      native_api \
+      default_codec_factory_objc \
+      peerconnection \
+      videocapture_objc \
+      mac_framework_objc
+
+    _branch="M`echo $WEBRTC_VERSION | cut -d'.' -f1`"
+    _commit="`echo $WEBRTC_VERSION | cut -d'.' -f3`"
+    _revision=$WEBRTC_COMMIT
+    _maint="`echo $WEBRTC_BUILD_VERSION | cut -d'.' -f4`"
+
+    cat <<EOF > $_libs_dir/WebRTC.framework/Resources/build_info.json
+{
+    "webrtc_version": "$_branch",
+    "webrtc_commit": "$_commit",
+    "webrtc_maint": "$_maint",
+    "webrtc_revision": "$_revision"
+}
+EOF
+
+    # info.plistの編集(tools_wertc/ios/build_ios_libs.py内の処理を踏襲)
+    _info_plist_path=$_libs_dir/WebRTC.framework/Resources/Info.plist
+    _major_minor=(echo -n `/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" $_info_plist_path`)
+    _version_number="$_major_minor.0"
+    /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $_version_number" $_info_plist_path
+    plutil -convert binary1 $_info_plist_path
+
+    pushd $_libs_dir/obj
+      /usr/bin/ar -rc $_libs_dir/libwebrtc.a `find . -name '*.o'`
+    popd
+
+    python2 tools_webrtc/libs/generate_licenses.py --target //sdk:mac_framework_objc $_libs_dir/WebRTC.framework/Resources $_libs_dir
+  done
 popd
 
-pushd $BUILD_DIR/webrtc/obj
-  /usr/bin/ar -rc $BUILD_DIR/webrtc/libwebrtc.a `find . -name '*.o'`
-popd
-
-./scripts/package_webrtc.sh $SCRIPT_DIR/static $SOURCE_DIR $BUILD_DIR $PACKAGE_DIR $SCRIPT_DIR/VERSION
+./scripts/package_webrtc_macos.sh $SCRIPT_DIR/static $SOURCE_DIR $BUILD_DIR $PACKAGE_DIR $SCRIPT_DIR/VERSION "$TARGET_BUILD_CONFIGS"

--- a/build.macos_arm64.sh
+++ b/build.macos_arm64.sh
@@ -31,9 +31,12 @@ pushd $SOURCE_DIR/webrtc/src
     target_os="mac"
     target_cpu="arm64"
     is_debug=false
+    enable_dsyms=false
+    enable_stripping=true
     rtc_include_tests=false
     rtc_build_examples=false
     rtc_use_h264=false
+    rtc_enable_symbol_export=true
     is_component_build=false
     use_rtti=true
     libcxx_abi_unstable=false

--- a/build.macos_arm64.sh
+++ b/build.macos_arm64.sh
@@ -45,8 +45,10 @@ pushd $SOURCE_DIR/webrtc/src
     native_api \
     default_codec_factory_objc \
     peerconnection \
-    videocapture_objc
-  python2 tools_webrtc/libs/generate_licenses.py --target :webrtc $BUILD_DIR/webrtc/ $BUILD_DIR/webrtc/
+    videocapture_objc \
+    mac_framework_objc
+
+  python2 tools_webrtc/libs/generate_licenses.py --target //sdk:mac_framework_objc $BUILD_DIR/webrtc/ $BUILD_DIR/webrtc/
 popd
 
 pushd $BUILD_DIR/webrtc/obj


### PR DESCRIPTION
#12 #13 と同様に、macOS arm64に対してもObjCのヘッダーファイルの出力を行いました。
主な対応内容は以下になります。

- ObjCヘッダーファイルを出力するために `mac_framework_objc` オプションを追加
- `Info.plist` の書き換えを行う
- debug/releaseビルドの作成

なお、ビルド成功時の `webrtc.tar.gz` は展開すると以下の構成になります。

```
webrtc
├── NOTICE
├── VERSIONS
├── debug
│   ├── WebRTC.dSYM
│   │   └── Contents
│   ├── WebRTC.framework
│   │   ├── Headers
│   │   ├── Modules
│   │   ├── Resources
│   │   ├── Versions
│   │   └── WebRTC
│   └── lib
│       └── libwebrtc.a
├── include
│   ├── api
(中略)
│   └── video
└── release
    ├── WebRTC.framework
    │   ├── Headers
    │   ├── Modules
    │   ├── Resources
    │   ├── Versions
    │   └── WebRTC
    └── lib
        └── libwebrtc.a
```