### PR TITLE
libwebrtc_onremovetrack.aar を libwebrtc.aar に統合する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,11 @@
 VERSION ファイルを上げただけの場合は変更履歴記録は不要。
 パッチやビルドの変更のみ記録すること。
 
+## develop
+
+- [CHANGE] libwebrtc_onremovetrack.aar を廃止して、 libwebrtc.aar に android_onremovetrack.patch を適用する
+    - @enm10k
+
 ## m91.4472.9.3
 
 - [ADD] 各環境のバイナリに zlib を追加

--- a/android/Dockerfile
+++ b/android/Dockerfile
@@ -33,13 +33,15 @@ COPY patches/4k.patch /root/patches/
 COPY patches/android_webrtc_version.patch /root/patches/
 COPY patches/android_fixsegv.patch /root/patches/
 COPY patches/android_simulcast.patch /root/patches/
+COPY patches/android_onremovetrack.patch /root/patches/
 COPY android/WebrtcBuildVersion.java $SOURCE_DIR/webrtc/src/sdk/android/api/org/webrtc/
 RUN cd $SOURCE_DIR/webrtc/src \
   && patch -p1 < /root/patches/add_dep_zlib.patch \
   && patch -p2 < /root/patches/4k.patch \
   && patch -p1 < /root/patches/android_webrtc_version.patch \
   && patch -p1 < /root/patches/android_fixsegv.patch \
-  && patch -p1 < /root/patches/android_simulcast.patch
+  && patch -p1 < /root/patches/android_simulcast.patch \
+  && patch -p1 < /root/patches/android_onremovetrack.patch
 
 RUN cd /root/_source/android/webrtc/src \
   && python $SOURCE_DIR/webrtc/src/tools_webrtc/android/build_aar.py \
@@ -87,25 +89,6 @@ RUN cd $SOURCE_DIR/webrtc/src \
 
 RUN cd $BUILD_DIR/webrtc_arm64-v8a/obj \
   && $SOURCE_DIR/webrtc/src/third_party/llvm-build/Release+Asserts/bin/llvm-ar -rc $BUILD_DIR/webrtc_arm64-v8a/libwebrtc.a `find . -name '*.o'`
-
-# onremovetrack 入りの aar
-# ソースが書き換わるので最後にやる必要がある
-COPY patches/android_onremovetrack.patch /root/patches/
-RUN cd $SOURCE_DIR/webrtc/src \
-  && patch -p1 < /root/patches/android_onremovetrack.patch
-
-RUN cd /root/_source/android/webrtc/src \
-  && python $SOURCE_DIR/webrtc/src/tools_webrtc/android/build_aar.py \
-      --build-dir $BUILD_DIR/webrtc_android \
-      --output $BUILD_DIR//webrtc_android/libwebrtc_onremovetrack.aar \
-      --arch armeabi-v7a arm64-v8a \
-      --extra-gn-args ' \
-        is_java_debug=false \
-        rtc_include_tests=false \
-        rtc_use_h264=false \
-        is_component_build=false \
-        use_rtti=true \
-      '
 
 ENV STATIC_DIR "/root/static"
 

--- a/android/Dockerfile
+++ b/android/Dockerfile
@@ -76,6 +76,12 @@ RUN cd $BUILD_DIR/webrtc_arm64-v8a/obj \
 
 # aar
 COPY patches/android_onremovetrack.patch /root/patches/
+
+# android_onremovetrack.patch を適用すると libwebrtc.a のビルドがエラーになるため、
+# このパッチのみ libwebrtc.aar をビルドする直前に適用しています
+#
+# ビルドエラーの詳細は以下のリンクを参照してください
+# https://github.com/shiguredo-webrtc-build/webrtc-build/pull/21#discussion_r656692110
 RUN cd $SOURCE_DIR/webrtc/src \
   && patch -p1 < /root/patches/android_onremovetrack.patch
 

--- a/android/Dockerfile
+++ b/android/Dockerfile
@@ -27,34 +27,18 @@ RUN cd $SOURCE_DIR/webrtc/src \
 COPY scripts/install_webrtc_build_deps.sh /root/scripts/
 RUN /root/scripts/install_webrtc_build_deps.sh $SOURCE_DIR android
 
-# 普通の aar
 COPY patches/add_dep_zlib.patch /root/patches/
 COPY patches/4k.patch /root/patches/
 COPY patches/android_webrtc_version.patch /root/patches/
 COPY patches/android_fixsegv.patch /root/patches/
 COPY patches/android_simulcast.patch /root/patches/
-COPY patches/android_onremovetrack.patch /root/patches/
 COPY android/WebrtcBuildVersion.java $SOURCE_DIR/webrtc/src/sdk/android/api/org/webrtc/
 RUN cd $SOURCE_DIR/webrtc/src \
   && patch -p1 < /root/patches/add_dep_zlib.patch \
   && patch -p2 < /root/patches/4k.patch \
   && patch -p1 < /root/patches/android_webrtc_version.patch \
   && patch -p1 < /root/patches/android_fixsegv.patch \
-  && patch -p1 < /root/patches/android_simulcast.patch \
-  && patch -p1 < /root/patches/android_onremovetrack.patch
-
-RUN cd /root/_source/android/webrtc/src \
-  && python $SOURCE_DIR/webrtc/src/tools_webrtc/android/build_aar.py \
-      --build-dir $BUILD_DIR/webrtc_android \
-      --output $BUILD_DIR//webrtc_android/libwebrtc.aar \
-      --arch armeabi-v7a arm64-v8a \
-      --extra-gn-args ' \
-        is_java_debug=false \
-        rtc_include_tests=false \
-        rtc_use_h264=false \
-        is_component_build=false \
-        use_rtti=true \
-      '
+  && patch -p1 < /root/patches/android_simulcast.patch
 
 # armeabi-v7a 用の libwebrtc.a
 RUN cd $SOURCE_DIR/webrtc/src \
@@ -89,6 +73,24 @@ RUN cd $SOURCE_DIR/webrtc/src \
 
 RUN cd $BUILD_DIR/webrtc_arm64-v8a/obj \
   && $SOURCE_DIR/webrtc/src/third_party/llvm-build/Release+Asserts/bin/llvm-ar -rc $BUILD_DIR/webrtc_arm64-v8a/libwebrtc.a `find . -name '*.o'`
+
+# aar
+COPY patches/android_onremovetrack.patch /root/patches/
+RUN cd $SOURCE_DIR/webrtc/src \
+  && patch -p1 < /root/patches/android_onremovetrack.patch
+
+RUN cd /root/_source/android/webrtc/src \
+  && python $SOURCE_DIR/webrtc/src/tools_webrtc/android/build_aar.py \
+      --build-dir $BUILD_DIR/webrtc_android \
+      --output $BUILD_DIR//webrtc_android/libwebrtc.aar \
+      --arch armeabi-v7a arm64-v8a \
+      --extra-gn-args ' \
+        is_java_debug=false \
+        rtc_include_tests=false \
+        rtc_use_h264=false \
+        is_component_build=false \
+        use_rtti=true \
+      '
 
 ENV STATIC_DIR "/root/static"
 

--- a/android/Dockerfile
+++ b/android/Dockerfile
@@ -33,12 +33,28 @@ COPY patches/android_webrtc_version.patch /root/patches/
 COPY patches/android_fixsegv.patch /root/patches/
 COPY patches/android_simulcast.patch /root/patches/
 COPY android/WebrtcBuildVersion.java $SOURCE_DIR/webrtc/src/sdk/android/api/org/webrtc/
+COPY patches/android_onremovetrack.patch /root/patches/
 RUN cd $SOURCE_DIR/webrtc/src \
   && patch -p1 < /root/patches/add_dep_zlib.patch \
   && patch -p2 < /root/patches/4k.patch \
   && patch -p1 < /root/patches/android_webrtc_version.patch \
   && patch -p1 < /root/patches/android_fixsegv.patch \
-  && patch -p1 < /root/patches/android_simulcast.patch
+  && patch -p1 < /root/patches/android_simulcast.patch \
+  && patch -p1 < /root/patches/android_onremovetrack.patch
+
+# aar
+RUN cd /root/_source/android/webrtc/src \
+  && python $SOURCE_DIR/webrtc/src/tools_webrtc/android/build_aar.py \
+      --build-dir $BUILD_DIR/webrtc_android \
+      --output $BUILD_DIR//webrtc_android/libwebrtc.aar \
+      --arch armeabi-v7a arm64-v8a \
+      --extra-gn-args ' \
+        is_java_debug=false \
+        rtc_include_tests=false \
+        rtc_use_h264=false \
+        is_component_build=false \
+        use_rtti=true \
+      '
 
 # armeabi-v7a 用の libwebrtc.a
 RUN cd $SOURCE_DIR/webrtc/src \
@@ -73,30 +89,6 @@ RUN cd $SOURCE_DIR/webrtc/src \
 
 RUN cd $BUILD_DIR/webrtc_arm64-v8a/obj \
   && $SOURCE_DIR/webrtc/src/third_party/llvm-build/Release+Asserts/bin/llvm-ar -rc $BUILD_DIR/webrtc_arm64-v8a/libwebrtc.a `find . -name '*.o'`
-
-# aar
-COPY patches/android_onremovetrack.patch /root/patches/
-
-# android_onremovetrack.patch を適用すると libwebrtc.a のビルドがエラーになるため、
-# このパッチのみ libwebrtc.aar をビルドする直前に適用しています
-#
-# ビルドエラーの詳細は以下のリンクを参照してください
-# https://github.com/shiguredo-webrtc-build/webrtc-build/pull/21#discussion_r656692110
-RUN cd $SOURCE_DIR/webrtc/src \
-  && patch -p1 < /root/patches/android_onremovetrack.patch
-
-RUN cd /root/_source/android/webrtc/src \
-  && python $SOURCE_DIR/webrtc/src/tools_webrtc/android/build_aar.py \
-      --build-dir $BUILD_DIR/webrtc_android \
-      --output $BUILD_DIR//webrtc_android/libwebrtc.aar \
-      --arch armeabi-v7a arm64-v8a \
-      --extra-gn-args ' \
-        is_java_debug=false \
-        rtc_include_tests=false \
-        rtc_use_h264=false \
-        is_component_build=false \
-        use_rtti=true \
-      '
 
 ENV STATIC_DIR "/root/static"
 

--- a/android/Dockerfile
+++ b/android/Dockerfile
@@ -54,6 +54,7 @@ RUN cd /root/_source/android/webrtc/src \
         rtc_use_h264=false \
         is_component_build=false \
         use_rtti=true \
+        rtc_build_examples=false \
       '
 
 # armeabi-v7a 用の libwebrtc.a
@@ -66,6 +67,7 @@ RUN cd $SOURCE_DIR/webrtc/src \
     rtc_include_tests=false \
     rtc_build_json=true \
     use_rtti=true \
+    rtc_build_examples=false \
   ' \
   && ninja -C $BUILD_DIR/webrtc_armeabi-v7a \
   && ninja -C $BUILD_DIR/webrtc_armeabi-v7a native_api
@@ -83,6 +85,7 @@ RUN cd $SOURCE_DIR/webrtc/src \
     rtc_include_tests=false \
     rtc_build_json=true \
     use_rtti=true \
+    rtc_build_examples=false \
   ' \
   && ninja -C $BUILD_DIR/webrtc_arm64-v8a \
   && ninja -C $BUILD_DIR/webrtc_arm64-v8a native_api

--- a/patches/android_onremovetrack.patch
+++ b/patches/android_onremovetrack.patch
@@ -1,16 +1,3 @@
-diff --git a/webrtc.gni b/webrtc.gni
-index b70cba633a..a7e82acc27 100644
---- a/webrtc.gni
-+++ b/webrtc.gni
-@@ -106,7 +106,7 @@ declare_args() {
-   rtc_enable_bwe_test_logging = false
- 
-   # Set this to false to skip building examples.
--  rtc_build_examples = true
-+  rtc_build_examples = false
- 
-   # Set this to false to skip building tools.
-   rtc_build_tools = true
 diff --git a/sdk/android/api/org/webrtc/PeerConnection.java b/sdk/android/api/org/webrtc/PeerConnection.java
 index b981520746..abda50766d 100644
 --- a/sdk/android/api/org/webrtc/PeerConnection.java

--- a/patches/android_onremovetrack.patch
+++ b/patches/android_onremovetrack.patch
@@ -1,3 +1,16 @@
+diff --git a/webrtc.gni b/webrtc.gni
+index b70cba633a..a7e82acc27 100644
+--- a/webrtc.gni
++++ b/webrtc.gni
+@@ -106,7 +106,7 @@ declare_args() {
+   rtc_enable_bwe_test_logging = false
+ 
+   # Set this to false to skip building examples.
+-  rtc_build_examples = true
++  rtc_build_examples = false
+ 
+   # Set this to false to skip building tools.
+   rtc_build_tools = true
 diff --git a/sdk/android/api/org/webrtc/PeerConnection.java b/sdk/android/api/org/webrtc/PeerConnection.java
 index b981520746..abda50766d 100644
 --- a/sdk/android/api/org/webrtc/PeerConnection.java

--- a/scripts/package_webrtc_android.sh
+++ b/scripts/package_webrtc_android.sh
@@ -24,7 +24,6 @@ rsync -amv '--include=*/' '--include=*.h' '--include=*.hpp' '--exclude=*' $SOURC
 
 # libwebrtc.aar, libwebrtc.a, NOTICE
 cp $BUILD_DIR/webrtc_android/libwebrtc.aar $BUILD_DIR/package/webrtc/aar/
-cp $BUILD_DIR/webrtc_android/libwebrtc_onremovetrack.aar $BUILD_DIR/package/webrtc/aar/
 mkdir -p $BUILD_DIR/package/webrtc/lib/armeabi-v7a/
 cp $BUILD_DIR/webrtc_armeabi-v7a/libwebrtc.a $BUILD_DIR/package/webrtc/lib/armeabi-v7a/
 mkdir -p $BUILD_DIR/package/webrtc/lib/arm64-v8a/


### PR DESCRIPTION
## 変更内容

- libwebrtc_onremovetrack.aar を廃止して、 libwebrtc.aar に android_onremovetrack.patch を適用しました