### PR TITLE
RTCVideoEncoderFactorySimulcastをmacOSでも使用可能にする

### DIFF
--- a/build.macos_arm64.sh
+++ b/build.macos_arm64.sh
@@ -27,6 +27,7 @@ pushd $SOURCE_DIR/webrtc/src
   patch -p2 < $SCRIPT_DIR/patches/macos_av1.patch
   patch -p2 < $SCRIPT_DIR/patches/macos_screen_capture.patch
   patch -p1 < $SCRIPT_DIR/patches/macos_simulcast.patch
+  patch -p1 < $SCRIPT_DIR/patches/ios_simulcast.patch
 popd
 
 pushd $SOURCE_DIR/webrtc/src

--- a/build.macos_x86_64.sh
+++ b/build.macos_x86_64.sh
@@ -27,6 +27,7 @@ pushd $SOURCE_DIR/webrtc/src
   patch -p2 < $SCRIPT_DIR/patches/macos_av1.patch
   patch -p2 < $SCRIPT_DIR/patches/macos_screen_capture.patch
   patch -p1 < $SCRIPT_DIR/patches/macos_simulcast.patch
+  patch -p1 < $SCRIPT_DIR/patches/ios_simulcast.patch
 popd
 
 pushd $SOURCE_DIR/webrtc/src

--- a/patches/ios_simulcast.patch
+++ b/patches/ios_simulcast.patch
@@ -130,7 +130,7 @@ new file mode 100644
 index 0000000000..7ce2a4eaba
 --- /dev/null
 +++ b/sdk/objc/components/video_codec/RTCVideoEncoderFactorySimulcast.mm
-@@ -0,0 +1,36 @@
+@@ -0,0 +1,39 @@
 +#import <Foundation/Foundation.h>
 +
 +#import "RTCMacros.h"
@@ -147,6 +147,9 @@ index 0000000000..7ce2a4eaba
 +
 +
 +@implementation RTC_OBJC_TYPE (RTCVideoEncoderFactorySimulcast)
++
++@synthesize primary = _primary;
++@synthesize fallback = _fallback;
 +
 +- (instancetype)initWithPrimary:(id<RTC_OBJC_TYPE(RTCVideoEncoderFactory)>)primary
 +                       fallback:(id<RTC_OBJC_TYPE(RTCVideoEncoderFactory)>)fallback {


### PR DESCRIPTION
macOSにてRTCVideoEncoderFactorySimulcast を利用可能にするため、 `ios_simulcast.patch` を  macOS向けのビルドスクリプトに追加します。

ただし、 `ios_simulcast.patch` をそのまま `build.macos_xx.sh` に組み込むだけでは、warningが発生し、ビルドがエラーになってしまいます。
これは、macOSでのビルド実行時に構築されるコマンド内に `-Wobjc-missing-property-synthesis` が組み込まれているためです。
そのため、 `@synthesize` を パッチに追記し、warningを解消することにしています。