### PR TITLE
macOSでもiOSと同様のリモート統計情報を送信できる

### DIFF
--- a/build.macos_arm64.sh
+++ b/build.macos_arm64.sh
@@ -28,6 +28,7 @@ pushd $SOURCE_DIR/webrtc/src
   patch -p2 < $SCRIPT_DIR/patches/macos_screen_capture.patch
   patch -p1 < $SCRIPT_DIR/patches/macos_simulcast.patch
   patch -p1 < $SCRIPT_DIR/patches/ios_simulcast.patch
+  patch -p1 < $SCRIPT_DIR/patches/macos_statistics.patch
 popd
 
 pushd $SOURCE_DIR/webrtc/src

--- a/build.macos_x86_64.sh
+++ b/build.macos_x86_64.sh
@@ -28,6 +28,7 @@ pushd $SOURCE_DIR/webrtc/src
   patch -p2 < $SCRIPT_DIR/patches/macos_screen_capture.patch
   patch -p1 < $SCRIPT_DIR/patches/macos_simulcast.patch
   patch -p1 < $SCRIPT_DIR/patches/ios_simulcast.patch
+  patch -p1 < $SCRIPT_DIR/patches/macos_statistics.patch
 popd
 
 pushd $SOURCE_DIR/webrtc/src

--- a/patches/macos_statistics.patch
+++ b/patches/macos_statistics.patch
@@ -1,0 +1,12 @@
+diff --git a/sdk/BUILD.gn b/sdk/BUILD.gn
+index e01ab97a6e..2c7689ebfe 100644
+--- a/sdk/BUILD.gn
++++ b/sdk/BUILD.gn
+@@ -1387,6 +1406,7 @@ if (is_ios || is_mac) {
+           "objc/api/peerconnection/RTCRtpTransceiver.h",
+           "objc/api/peerconnection/RTCSSLAdapter.h",
+           "objc/api/peerconnection/RTCSessionDescription.h",
++          "objc/api/peerconnection/RTCStatisticsReport.h",
+           "objc/api/peerconnection/RTCTracing.h",
+           "objc/api/peerconnection/RTCVideoSource.h",
+           "objc/api/peerconnection/RTCVideoTrack.h",


### PR DESCRIPTION
[背景]
Sora iOS SDKでは `RTCStatisticsReport` を利用していますが、 `RTCStatisticsReport` はiOS向けにのみヘッダーが公開されています。現状macOSで統計情報を送信するには `RTCLegacyStatsReport` のみしか使うことができません。
`RTCLegacyStatsReport` と `RTCStatisticsReport` は内部的に利用しているStatsのクラスが異なることから、macOSではiOSとStatsの中見が異なってしまいます。

[対応内容]
macOSでもiOSと同様に `RTCStatisticsReport` を利用可能にするためにヘッダーを公開します。

[メリット]
- リモート統計情報の送信箇所をiOSとmacOSで実装を合わせることができます
- Soraのリモート統計情報APIのレスポンスもiOSと同様な形で確認できるようになります

[デメリット]
- 特にありません