### PR TITLE
libjpeg_turbo の ビルド時に MANGLE_JPEG_NAMES を指定する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@ VERSION ファイルを上げただけの場合は変更履歴記録は不要。
 
 - [CHANGE] libwebrtc_onremovetrack.aar を廃止して、 libwebrtc.aar に android_onremovetrack.patch を適用する
     - @enm10k
+- [FIX] third_party/libjpeg_turbo の jpeglibmangler.h が機能していない問題を修正するパッチを追加する
+    - @enm10k
 
 ## m91.4472.9.3
 

--- a/build.macos_arm64.sh
+++ b/build.macos_arm64.sh
@@ -29,6 +29,10 @@ pushd $SOURCE_DIR/webrtc/src
   patch -p1 < $SCRIPT_DIR/patches/macos_simulcast.patch
   patch -p1 < $SCRIPT_DIR/patches/ios_simulcast.patch
   patch -p1 < $SCRIPT_DIR/patches/macos_statistics.patch
+
+  pushd third_party/libjpeg_turbo
+    patch < $SCRIPT_DIR/patches/libjpeg_turbo_mangle_jpeg_names.patch
+  popd
 popd
 
 pushd $SOURCE_DIR/webrtc/src

--- a/build.macos_x86_64.sh
+++ b/build.macos_x86_64.sh
@@ -29,6 +29,10 @@ pushd $SOURCE_DIR/webrtc/src
   patch -p1 < $SCRIPT_DIR/patches/macos_simulcast.patch
   patch -p1 < $SCRIPT_DIR/patches/ios_simulcast.patch
   patch -p1 < $SCRIPT_DIR/patches/macos_statistics.patch
+
+  pushd third_party/libjpeg_turbo
+    patch < $SCRIPT_DIR/patches/libjpeg_turbo_mangle_jpeg_names.patch
+  popd
 popd
 
 pushd $SOURCE_DIR/webrtc/src

--- a/build.windows.ps1
+++ b/build.windows.ps1
@@ -103,6 +103,10 @@ Push-Location $WEBRTC_DIR\src
   git apply -p2 --ignore-space-change --ignore-whitespace --whitespace=nowarn $SCRIPT_DIR\patches\4k.patch
   git apply -p1 --ignore-space-change --ignore-whitespace --whitespace=nowarn $SCRIPT_DIR\patches\windows_add_deps.patch
 
+  Push-Location third_party/libjpeg_turbo
+    git apply --ignore-space-change --ignore-whitespace --whitespace=nowarn $SCRIPT_DIR\patches\libjpeg_turbo_mangle_jpeg_names.patch
+  Pop-Location
+
   # WebRTC ビルド
   gn gen $WEBRTC_BUILD_DIR\debug --args='is_debug=true rtc_include_tests=false rtc_use_h264=false is_component_build=false use_rtti=true use_custom_libcxx=false'
   ninja -C "$WEBRTC_BUILD_DIR\debug"

--- a/patches/README.md
+++ b/patches/README.md
@@ -41,6 +41,14 @@
 
 ## nacl_armv6_2.patch
 
+## libjpeg_turbo_mangle_jpeg_names.patch
+
+libwebrtc (chromium) には、利用している libjpeg がシステムの libjpeg と混ざることを防ぐ仕組みがあるが、それが M93 から壊れている。  
+結果、 momo の一部の機能が正常に動作しなくなったため、パッチを当てて壊れる前の状態にしている。
+
+libjpeg が混ざることを防ぐ仕組みの解説 https://source.chromium.org/chromium/chromium/src/+/master:third_party/libjpeg_turbo/README.chromium;l=30-34;drc=ff19e5b2e176c61d552f68768e0e051867745321  
+問題の原因と思われる変更 https://chromium-review.googlesource.com/c/chromium/deps/libjpeg_turbo/+/2872069  
+本家のイシューに報告済み https://bugs.chromium.org/p/webrtc/issues/detail?id=13101  
 
 ## ubuntu_nolibcxx.patch
 

--- a/patches/libjpeg_turbo_mangle_jpeg_names.patch
+++ b/patches/libjpeg_turbo_mangle_jpeg_names.patch
@@ -1,24 +1,24 @@
 diff --git a/BUILD.gn b/BUILD.gn
-index d566340..ebc4719 100644
+index d566340..8885a52 100644
 --- a/BUILD.gn
 +++ b/BUILD.gn
-@@ -175,7 +175,10 @@ static_library("simd") {
-       ]
-     }
+@@ -12,6 +12,10 @@ if (current_cpu == "arm" || current_cpu == "arm64") {
  
--    defines = [ "NEON_INTRINSICS" ]
-+    defines = [
-+      "NEON_INTRINSICS",
-+      "MANGLE_JPEG_NAMES",
-+    ]
+ assert(!is_ios, "This is not used on iOS, don't drag it in unintentionally")
  
-     configs -= [ "//build/config/compiler:default_optimization" ]
-     configs += [ "//build/config/compiler:optimize_speed" ]
-@@ -190,6 +193,7 @@ static_library("simd") {
- 
- config("libjpeg_config") {
-   include_dirs = [ "." ]
++config("libjpeg_headers_config") {
 +  defines = [ "MANGLE_JPEG_NAMES" ]
++}
++
+ source_set("libjpeg_headers") {
+   sources = [
+     "jconfig.h",
+@@ -21,7 +25,7 @@ source_set("libjpeg_headers") {
+     "jpeglib.h",
+     "jpeglibmangler.h",
+   ]
+-  defines = [ "MANGLE_JPEG_NAMES" ]
++  public_configs = [ ":libjpeg_headers_config" ]
  }
  
- static_library("libjpeg") {
+ if (current_cpu == "x86" || current_cpu == "x64") {

--- a/patches/libjpeg_turbo_mangle_jpeg_names.patch
+++ b/patches/libjpeg_turbo_mangle_jpeg_names.patch
@@ -1,24 +1,24 @@
 diff --git a/BUILD.gn b/BUILD.gn
-index d566340..8885a52 100644
+index d566340..ebc4719 100644
 --- a/BUILD.gn
 +++ b/BUILD.gn
-@@ -12,6 +12,10 @@ if (current_cpu == "arm" || current_cpu == "arm64") {
+@@ -175,7 +175,10 @@ static_library("simd") {
+       ]
+     }
  
- assert(!is_ios, "This is not used on iOS, don't drag it in unintentionally")
+-    defines = [ "NEON_INTRINSICS" ]
++    defines = [
++      "NEON_INTRINSICS",
++      "MANGLE_JPEG_NAMES",
++    ]
  
-+config("libjpeg_headers_config") {
+     configs -= [ "//build/config/compiler:default_optimization" ]
+     configs += [ "//build/config/compiler:optimize_speed" ]
+@@ -190,6 +193,7 @@ static_library("simd") {
+ 
+ config("libjpeg_config") {
+   include_dirs = [ "." ]
 +  defines = [ "MANGLE_JPEG_NAMES" ]
-+}
-+
- source_set("libjpeg_headers") {
-   sources = [
-     "jconfig.h",
-@@ -21,7 +25,7 @@ source_set("libjpeg_headers") {
-     "jpeglib.h",
-     "jpeglibmangler.h",
-   ]
--  defines = [ "MANGLE_JPEG_NAMES" ]
-+  public_configs = [ ":libjpeg_headers_config" ]
  }
  
- if (current_cpu == "x86" || current_cpu == "x64") {
+ static_library("libjpeg") {

--- a/patches/libjpeg_turbo_mangle_jpeg_names.patch
+++ b/patches/libjpeg_turbo_mangle_jpeg_names.patch
@@ -1,20 +1,25 @@
 diff --git a/BUILD.gn b/BUILD.gn
-index d566340..ebc4719 100644
+index d566340..4cf5cd3 100644
 --- a/BUILD.gn
 +++ b/BUILD.gn
-@@ -175,7 +175,10 @@ static_library("simd") {
+@@ -21,7 +21,6 @@ source_set("libjpeg_headers") {
+     "jpeglib.h",
+     "jpeglibmangler.h",
+   ]
+-  defines = [ "MANGLE_JPEG_NAMES" ]
+ }
+ 
+ if (current_cpu == "x86" || current_cpu == "x64") {
+@@ -175,7 +174,7 @@ static_library("simd") {
        ]
      }
  
 -    defines = [ "NEON_INTRINSICS" ]
-+    defines = [
-+      "NEON_INTRINSICS",
-+      "MANGLE_JPEG_NAMES",
-+    ]
++    defines = [ "NEON_INTRINSICS", "MANGLE_JPEG_NAMES" ]
  
      configs -= [ "//build/config/compiler:default_optimization" ]
      configs += [ "//build/config/compiler:optimize_speed" ]
-@@ -190,6 +193,7 @@ static_library("simd") {
+@@ -190,6 +189,7 @@ static_library("simd") {
  
  config("libjpeg_config") {
    include_dirs = [ "." ]

--- a/patches/libjpeg_turbo_mangle_jpeg_names.patch
+++ b/patches/libjpeg_turbo_mangle_jpeg_names.patch
@@ -1,0 +1,24 @@
+diff --git a/BUILD.gn b/BUILD.gn
+index d566340..ebc4719 100644
+--- a/BUILD.gn
++++ b/BUILD.gn
+@@ -175,7 +175,10 @@ static_library("simd") {
+       ]
+     }
+ 
+-    defines = [ "NEON_INTRINSICS" ]
++    defines = [
++      "NEON_INTRINSICS",
++      "MANGLE_JPEG_NAMES",
++    ]
+ 
+     configs -= [ "//build/config/compiler:default_optimization" ]
+     configs += [ "//build/config/compiler:optimize_speed" ]
+@@ -190,6 +193,7 @@ static_library("simd") {
+ 
+ config("libjpeg_config") {
+   include_dirs = [ "." ]
++  defines = [ "MANGLE_JPEG_NAMES" ]
+ }
+ 
+ static_library("libjpeg") {

--- a/raspberry-pi-os_armv6/Dockerfile
+++ b/raspberry-pi-os_armv6/Dockerfile
@@ -29,10 +29,13 @@ RUN /root/scripts/install_webrtc_build_deps.sh $SOURCE_DIR arm
 COPY patches/nacl_armv6_2.patch /root/patches/
 COPY patches/add_dep_zlib.patch /root/patches/
 COPY patches/4k.patch /root/patches/
+COPY patches/libjpeg_turbo_mangle_jpeg_names.patch /root/patches/
 RUN cd $SOURCE_DIR/webrtc/src \
   && patch -p1 < /root/patches/nacl_armv6_2.patch \
   && patch -p1 < /root/patches/add_dep_zlib.patch \
-  && patch -p2 < /root/patches/4k.patch
+  && patch -p2 < /root/patches/4k.patch \
+  && cd $SOURCE_DIR/webrtc/src/third_party/libjpeg_turbo \
+  && patch < /root/patches/libjpeg_turbo_mangle_jpeg_names.patch
 
 RUN cd $SOURCE_DIR/webrtc/src \
   && gn gen $BUILD_DIR/webrtc --args=' \

--- a/raspberry-pi-os_armv7/Dockerfile
+++ b/raspberry-pi-os_armv7/Dockerfile
@@ -28,9 +28,12 @@ RUN /root/scripts/install_webrtc_build_deps.sh $SOURCE_DIR arm
 
 COPY patches/add_dep_zlib.patch /root/patches/
 COPY patches/4k.patch /root/patches/
+COPY patches/libjpeg_turbo_mangle_jpeg_names.patch /root/patches/
 RUN cd $SOURCE_DIR/webrtc/src \
   && patch -p1 < /root/patches/add_dep_zlib.patch \
-  && patch -p2 < /root/patches/4k.patch
+  && patch -p2 < /root/patches/4k.patch \
+  && cd $SOURCE_DIR/webrtc/src/third_party/libjpeg_turbo \
+  && patch < /root/patches/libjpeg_turbo_mangle_jpeg_names.patch
 
 RUN cd $SOURCE_DIR/webrtc/src \
   && gn gen $BUILD_DIR/webrtc --args=' \

--- a/raspberry-pi-os_armv8/Dockerfile
+++ b/raspberry-pi-os_armv8/Dockerfile
@@ -28,9 +28,12 @@ RUN /root/scripts/install_webrtc_build_deps.sh $SOURCE_DIR arm
 
 COPY patches/add_dep_zlib.patch /root/patches/
 COPY patches/4k.patch /root/patches/
+COPY patches/libjpeg_turbo_mangle_jpeg_names.patch /root/patches/
 RUN cd $SOURCE_DIR/webrtc/src \
   && patch -p1 < /root/patches/add_dep_zlib.patch \
-  && patch -p2 < /root/patches/4k.patch
+  && patch -p2 < /root/patches/4k.patch \
+  && cd $SOURCE_DIR/webrtc/src/third_party/libjpeg_turbo \
+  && patch < /root/patches/libjpeg_turbo_mangle_jpeg_names.patch
 
 RUN cd $SOURCE_DIR/webrtc/src \
   && gn gen $BUILD_DIR/webrtc --args=' \

--- a/ubuntu-18.04_armv8/Dockerfile
+++ b/ubuntu-18.04_armv8/Dockerfile
@@ -28,9 +28,12 @@ RUN /root/scripts/install_webrtc_build_deps.sh $SOURCE_DIR arm
 
 COPY patches/add_dep_zlib.patch /root/patches/
 COPY patches/4k.patch /root/patches/
+COPY patches/libjpeg_turbo_mangle_jpeg_names.patch /root/patches/
 RUN cd $SOURCE_DIR/webrtc/src \
   && patch -p1 < /root/patches/add_dep_zlib.patch \
-  && patch -p2 < /root/patches/4k.patch
+  && patch -p2 < /root/patches/4k.patch \
+  && cd $SOURCE_DIR/webrtc/src/third_party/libjpeg_turbo \
+  && patch < /root/patches/libjpeg_turbo_mangle_jpeg_names.patch
 
 RUN cd $SOURCE_DIR/webrtc/src \
   && gn gen $BUILD_DIR/webrtc --args=' \

--- a/ubuntu-18.04_x86_64/Dockerfile
+++ b/ubuntu-18.04_x86_64/Dockerfile
@@ -23,8 +23,11 @@ COPY scripts/install_webrtc_build_deps.sh /root/scripts/
 RUN /root/scripts/install_webrtc_build_deps.sh $SOURCE_DIR x86_64
 
 COPY patches/4k.patch /root/patches/
+COPY patches/libjpeg_turbo_mangle_jpeg_names.patch /root/patches/
 RUN cd $SOURCE_DIR/webrtc/src \
-  && patch -p2 < /root/patches/4k.patch
+  && patch -p2 < /root/patches/4k.patch \
+  && cd $SOURCE_DIR/webrtc/src/third_party/libjpeg_turbo \
+  && patch < /root/patches/libjpeg_turbo_mangle_jpeg_names.patch
 
 RUN cd $SOURCE_DIR/webrtc/src \
   && gn gen $BUILD_DIR/webrtc --args=' \

--- a/ubuntu-20.04_x86_64/Dockerfile
+++ b/ubuntu-20.04_x86_64/Dockerfile
@@ -20,8 +20,11 @@ COPY scripts/prepare_webrtc.sh /root/scripts/
 RUN /root/scripts/prepare_webrtc.sh $SOURCE_DIR $WEBRTC_COMMIT
 
 COPY patches/4k.patch /root/patches/
+COPY patches/libjpeg_turbo_mangle_jpeg_names.patch /root/patches/
 RUN cd $SOURCE_DIR/webrtc/src \
-  && patch -p2 < /root/patches/4k.patch
+  && patch -p2 < /root/patches/4k.patch \
+  && cd $SOURCE_DIR/webrtc/src/third_party/libjpeg_turbo \
+  && patch < /root/patches/libjpeg_turbo_mangle_jpeg_names.patch
 
 COPY scripts/install_webrtc_build_deps.sh /root/scripts/
 RUN /root/scripts/install_webrtc_build_deps.sh $SOURCE_DIR x86_64


### PR DESCRIPTION
## 変更内容

libwebrtc (chromium) には、利用している libjpeg がシステムの libjpeg と混ざることを防ぐ仕組みがあります。
参照: https://source.chromium.org/chromium/chromium/src/+/master:third_party/libjpeg_turbo/README.chromium;l=30-34;drc=ff19e5b2e176c61d552f68768e0e051867745321

(おそらく) https://chromium-review.googlesource.com/c/chromium/deps/libjpeg_turbo/+/2872069 が原因でその仕組が壊れて、 momo の一部の機能が WebRTC M93 で動作しなくなっている問題を修正します。

当面は、 momo で利用される可能性のある全てのバイナリにパッチを適用してはどうかと考えています。