### PR TITLE
s/android.support.annotation.Nullable/androidx.annotation.Nullable/g

### DIFF
--- a/patches/android_simulcast.patch
+++ b/patches/android_simulcast.patch
@@ -93,7 +93,7 @@ index 0000000000..80f9a50606
 +
 +package org.webrtc;
 +
-+import android.support.annotation.Nullable;
++import androidx.annotation.Nullable;
 +import java.util.ArrayList;
 +import java.util.HashMap;
 +import java.util.List;


### PR DESCRIPTION
## 変更内容

- m95 でビルドがこけていた箇所を修正しました
  - Android のパッチで利用している Nullable が androidx の下に移ったようです