### PR TITLE
macOSでxcframeworkに対応する

### DIFF
--- a/build.macos_arm64.sh
+++ b/build.macos_arm64.sh
@@ -39,10 +39,8 @@ pushd $SOURCE_DIR/webrtc/src
 
     if [ $_build_config = "release" ]; then
       _is_debug="false"
-      _enable_dsyms="false"
     else
       _is_debug="true"
-      _enable_dsyms="true"
     fi
 
 
@@ -50,7 +48,7 @@ pushd $SOURCE_DIR/webrtc/src
       target_os=\"mac\"
       target_cpu=\"arm64\"
       enable_stripping=true
-      enable_dsyms=$_enable_dsyms
+      enable_dsyms=true
       is_debug=$_is_debug
       rtc_include_tests=false
       rtc_build_examples=false

--- a/build.macos_arm64.sh
+++ b/build.macos_arm64.sh
@@ -94,6 +94,11 @@ EOF
     popd
 
     python2 tools_webrtc/libs/generate_licenses.py --target //sdk:mac_framework_objc $_libs_dir/WebRTC.framework/Resources $_libs_dir
+
+    # xcframeworkの作成
+    xcodebuild -create-xcframework \
+          -framework $BUILD_DIR/webrtc/${_build_config}/WebRTC.framework -debug-symbols $BUILD_DIR/webrtc/$_build_config/WebRTC.dSYM \
+          -output $BUILD_DIR/webrtc/${_build_config}/WebRTC.xcframework
   done
 popd
 

--- a/build.macos_x86_64.sh
+++ b/build.macos_x86_64.sh
@@ -39,10 +39,8 @@ pushd $SOURCE_DIR/webrtc/src
 
     if [ $_build_config = "release" ]; then
       _is_debug="false"
-      _enable_dsyms="false"
     else
       _is_debug="true"
-      _enable_dsyms="true"
     fi
 
     gn gen $_libs_dir --args="
@@ -50,7 +48,7 @@ pushd $SOURCE_DIR/webrtc/src
       target_cpu=\"$TARGET_ARCH\"
       mac_deployment_target=\"$MAC_DEPLOYMENT_TARGET\"
       enable_stripping=true
-      enable_dsyms=$_enable_dsyms
+      enable_dsyms=true
       is_debug=$_is_debug
       rtc_include_tests=false
       rtc_build_examples=false

--- a/build.macos_x86_64.sh
+++ b/build.macos_x86_64.sh
@@ -95,6 +95,11 @@ EOF
     popd
 
     python2 tools_webrtc/libs/generate_licenses.py --target //sdk:mac_framework_objc $_libs_dir/WebRTC.framework/Resources $_libs_dir
+
+    # xcframeworkの作成
+    xcodebuild -create-xcframework \
+          -framework $BUILD_DIR/webrtc/${_build_config}/WebRTC.framework -debug-symbols $BUILD_DIR/webrtc/$_build_config/WebRTC.dSYM \
+          -output $BUILD_DIR/webrtc/${_build_config}/WebRTC.xcframework
   done
 popd
 

--- a/scripts/package_webrtc_macos.sh
+++ b/scripts/package_webrtc_macos.sh
@@ -32,9 +32,7 @@ for _build_config in $TARGET_BUILD_CONFIGS; do
   cp -R $BUILD_DIR/webrtc/${_build_config}/WebRTC.framework "$BUILD_DIR/package/webrtc/${_build_config}/WebRTC.framework"
 
   # WebRTC.dSYM
-  if [ $_build_config = "debug" ]; then
-    cp -R $BUILD_DIR/webrtc/$_build_config/WebRTC.dSYM "$BUILD_DIR/package/webrtc/$_build_config/WebRTC.dSYM"
-  fi
+  cp -R $BUILD_DIR/webrtc/$_build_config/WebRTC.dSYM "$BUILD_DIR/package/webrtc/$_build_config/WebRTC.dSYM"
 
   # 各種情報を拾ってくる
   cp $VERSION_FILE $BUILD_DIR/package/webrtc/$_build_config/VERSIONS

--- a/scripts/package_webrtc_macos.sh
+++ b/scripts/package_webrtc_macos.sh
@@ -34,6 +34,9 @@ for _build_config in $TARGET_BUILD_CONFIGS; do
   # WebRTC.dSYM
   cp -R $BUILD_DIR/webrtc/$_build_config/WebRTC.dSYM "$BUILD_DIR/package/webrtc/$_build_config/WebRTC.dSYM"
 
+  # WebRTC.xcframework
+  cp -R $BUILD_DIR/webrtc/${_build_config}/WebRTC.xcframework "$BUILD_DIR/package/webrtc/${_build_config}/WebRTC.xcframework"
+
   # 各種情報を拾ってくる
   cp $VERSION_FILE $BUILD_DIR/package/webrtc/$_build_config/VERSIONS
   pushd $SOURCE_DIR/webrtc/src

--- a/scripts/package_webrtc_macos.sh
+++ b/scripts/package_webrtc_macos.sh
@@ -28,12 +28,6 @@ for _build_config in $TARGET_BUILD_CONFIGS; do
   # NOTICE
   cp $BUILD_DIR/webrtc/${_build_config}/WebRTC.framework/Resources/LICENSE.md "$BUILD_DIR/package/webrtc/NOTICE"
 
-  # WebRTC.framework
-  cp -R $BUILD_DIR/webrtc/${_build_config}/WebRTC.framework "$BUILD_DIR/package/webrtc/${_build_config}/WebRTC.framework"
-
-  # WebRTC.dSYM
-  cp -R $BUILD_DIR/webrtc/$_build_config/WebRTC.dSYM "$BUILD_DIR/package/webrtc/$_build_config/WebRTC.dSYM"
-
   # WebRTC.xcframework
   cp -R $BUILD_DIR/webrtc/${_build_config}/WebRTC.xcframework "$BUILD_DIR/package/webrtc/${_build_config}/WebRTC.xcframework"
 


### PR DESCRIPTION
### 背景

1. webrtc m93にてiOS向けに `WebRTC.xcframework` が出力されるようになりました
2. 従来、CocoaPodsで `WebRTC.framework` の配布を行う場合、CocoaPods単体では `WebRTC.dSYM` をアプリケーションのアーカイブに含めることができず、利用者側で何らかのスクリプトを書く必要がありました。

### 対応内容

macOS `x86_64` / `arm64` 両方のアーキテクチャにて以下の対応をしています。
- debug/release ビルドに関わらずdSYMを出力する
- ビルド済みの `WebRTC.framework` / `WebRTC.dSYM` を基に `WebRTC.xcframework` を生成する


### メリット

- release バイナリのクラッシュレポートをフレームワーク利用者が読めるようになる
- CocoaPods が `1.9` から `.xcframework` に対応したことで、`.xcframework` を使えば `WebRTC.dSYM` のエクスポートが容易になる

### デメリット

- 特にありません

### 備考

今回、`WebRTC.framework` と `WebRTC.dSYM` は従来通り `webrtc.tar.gz` 内に残したままにしています。
理由としては、 `x86_64` と `arm64` の両アーキテクチャ向けの単一の`WebRTC.xcframework` を提供したい利用者は自身で `xcodebuild -create-xcframework` を行っていただくことになります。その際 `lipo` コマンドでユニバーサルな `WebRTC.framework` 、`WebRTC.dSYM` を事前に作る必要があるためです。
