### PR TITLE
iOS向けビルド時の出力設定を合わせる

### DIFF
--- a/build.ios.sh
+++ b/build.ios.sh
@@ -44,13 +44,11 @@ pushd $SOURCE_DIR/webrtc/src
 
     if [ $build_config = "release" ]; then
       _is_debug="false"
-      _bitcode="--bitcode"
     else
       _is_debug="true"
-      _bitcode=""
     fi
 
-    ./tools_webrtc/ios/build_ios_libs.sh -o $BUILD_DIR/webrtc/$build_config --build_config $build_config --arch $TARGET_ARCHS $_bitcode --extra-gn-args " \
+    ./tools_webrtc/ios/build_ios_libs.sh -o $BUILD_DIR/webrtc/$build_config --build_config $build_config --arch $TARGET_ARCHS --bitcode --extra-gn-args " \
       use_xcode_clang=false \
       rtc_libvpx_build_vp9=true \
       rtc_include_tests=false \
@@ -88,10 +86,8 @@ pushd $SOURCE_DIR/webrtc/src
 
     if [ $build_config = "release" ]; then
       _is_debug="false"
-      _enable_bitcode="true"
     else
       _is_debug="true"
-      _enable_bitcode="false"
     fi
 
     for arch in $TARGET_ARCHS; do
@@ -106,7 +102,7 @@ pushd $SOURCE_DIR/webrtc/src
         rtc_enable_symbol_export=true
         rtc_enable_objc_symbol_export=false
         is_debug=$_is_debug
-        enable_ios_bitcode=$_enable_bitcode
+        enable_ios_bitcode=true
         enable_dsyms=true
         enable_stripping=true
 

--- a/build.ios.sh
+++ b/build.ios.sh
@@ -107,7 +107,7 @@ pushd $SOURCE_DIR/webrtc/src
         rtc_enable_objc_symbol_export=false
         is_debug=$_is_debug
         enable_ios_bitcode=$_enable_bitcode
-        enable_dsyms=$_is_debug
+        enable_dsyms=true
         enable_stripping=true
 
         rtc_include_tests=false

--- a/build.ios.sh
+++ b/build.ios.sh
@@ -88,8 +88,10 @@ pushd $SOURCE_DIR/webrtc/src
 
     if [ $build_config = "release" ]; then
       _is_debug="false"
+      _enable_bitcode="true"
     else
       _is_debug="true"
+      _enable_bitcode="false"
     fi
 
     for arch in $TARGET_ARCHS; do
@@ -104,7 +106,7 @@ pushd $SOURCE_DIR/webrtc/src
         rtc_enable_symbol_export=true
         rtc_enable_objc_symbol_export=false
         is_debug=$_is_debug
-        enable_ios_bitcode=$_is_debug
+        enable_ios_bitcode=$_enable_bitcode
         enable_dsyms=$_is_debug
         enable_stripping=true
 


### PR DESCRIPTION
[背景]
Sora iOS SDK をビルドしていた時に、WebRTC.xcframeworkにbitcodeが存在しない旨のエラーメッセージが出力されました。
確認したところ、Unity向けのビルドとそうでないビルドでbitcodeが異なっていることに気づきました。

[対応内容]
以下2点の設定変更を行なっています。
- iOS向けのwebrtc-buildにおいて ~~relase ビルドの際には~~ debug/release ビルド問わず bitcodeを有効化する
  - ~~以前の設定に戻す形になります~~
- dSYMの出力もUnity向けバイナリと合わせて常にtrueとする

[メリット]
- 従来通り、リリースビルド時にbitcode=YESによるビルドが可能になる
- releaseビルド向けのdebug symbolを開発者が使うことができるようになる

[デメリット]
- 特になし

 