### PR TITLE
bitcodeを有効にするためにはuse_xcode_clang=trueが必要だった

### DIFF
--- a/build.ios.sh
+++ b/build.ios.sh
@@ -49,7 +49,7 @@ pushd $SOURCE_DIR/webrtc/src
     fi
 
     ./tools_webrtc/ios/build_ios_libs.sh -o $BUILD_DIR/webrtc/$build_config --build_config $build_config --arch $TARGET_ARCHS --bitcode --extra-gn-args " \
-      use_xcode_clang=false \
+      use_xcode_clang=true \
       rtc_libvpx_build_vp9=true \
       rtc_include_tests=false \
       rtc_build_examples=false \
@@ -95,7 +95,7 @@ pushd $SOURCE_DIR/webrtc/src
         target_os=\"ios\"
         target_cpu=\"$arch\"
         ios_enable_code_signing=false
-        use_xcode_clang=false
+        use_xcode_clang=true
         is_component_build=false
         ios_deployment_target=\"$IOS_DEPLOYMENT_TARGET\"
         rtc_libvpx_build_vp9=true


### PR DESCRIPTION
[背景]
#31 にてiOSビルド時のbitcodeの有効化設定を追加しましたが、不足がありました。
`src/build/config/ios/BUILD.gn` を確認したところ、以下のような処理ブロックがあり、`use_xcode_clang=true` でビルドする必要があります。

```
  if (use_xcode_clang && enable_ios_bitcode && target_environment == "device") {
    if (is_debug) {
      common_flags += [ "-fembed-bitcode-marker" ]
    } else {
      common_flags += [ "-fembed-bitcode" ]
    }
  }
```

[対応内容]
- `use_xcode_clang=true` を追加

[相談事項]
81f3a809225f32bdf4c4905990a6c20e9d11962b を拝見するに、意図的にXCodeのClang利用を回避しているように見受けられるのですが、私の知識が浅く、判断しかねるため、 `use_xcode_clang=true` を入れて良いかご意見いただきたいです。