### PR TITLE
SimulcastVideoEncoderFactory の fallback に null を渡せるようにする

### DIFF
--- a/patches/android_simulcast.patch
+++ b/patches/android_simulcast.patch
@@ -77,10 +77,10 @@ index 0000000000..dee1c91fae
 +
 diff --git a/sdk/android/api/org/webrtc/SimulcastVideoEncoderFactory.java b/sdk/android/api/org/webrtc/SimulcastVideoEncoderFactory.java
 new file mode 100644
-index 0000000000..80f9a50606
+index 0000000000..848d65353a
 --- /dev/null
 +++ b/sdk/android/api/org/webrtc/SimulcastVideoEncoderFactory.java
-@@ -0,0 +1,43 @@
+@@ -0,0 +1,45 @@
 +/*
 + *  Copyright 2017 The WebRTC project authors. All Rights Reserved.
 + *
@@ -119,15 +119,16 @@ index 0000000000..80f9a50606
 +    public VideoCodecInfo[] getSupportedCodecs() {
 +        List<VideoCodecInfo> codecs = new ArrayList<VideoCodecInfo>();
 +        codecs.addAll(Arrays.asList(primary.getSupportedCodecs()));
-+        codecs.addAll(Arrays.asList(fallback.getSupportedCodecs()));
++        if (fallback != null) {
++            codecs.addAll(Arrays.asList(fallback.getSupportedCodecs()));
++        }
 +        return codecs.toArray(new VideoCodecInfo[codecs.size()]);
 +    }
 +
 +}
-
 diff --git a/sdk/android/src/jni/simulcast_video_encoder.cc b/sdk/android/src/jni/simulcast_video_encoder.cc
 new file mode 100644
-index 0000000000..2928cdab92
+index 0000000000..c43bef9dae
 --- /dev/null
 +++ b/sdk/android/src/jni/simulcast_video_encoder.cc
 @@ -0,0 +1,36 @@
@@ -157,7 +158,7 @@ index 0000000000..2928cdab92
 +    // https://github.com/shiguredo-webrtc-build/webrtc-build/pull/16#pullrequestreview-600675795
 +    return NativeToJavaPointer(std::make_unique<SimulcastEncoderAdapter>(
 +			    JavaToNativeVideoEncoderFactory(env, primary).release(),
-+			    JavaToNativeVideoEncoderFactory(env, fallback).release(),
++			    fallback != nullptr ? JavaToNativeVideoEncoderFactory(env, fallback).release() : nullptr,
 +			    format).release());
 +}
 +

--- a/patches/android_simulcast.patch
+++ b/patches/android_simulcast.patch
@@ -70,7 +70,7 @@ index 0000000000..dee1c91fae
 +
 +    @Override
 +    public boolean isHardwareEncoder() {
-+        return false;
++        return true;
 +    }
 +
 +}

--- a/patches/android_simulcast.patch
+++ b/patches/android_simulcast.patch
@@ -70,7 +70,7 @@ index 0000000000..dee1c91fae
 +
 +    @Override
 +    public boolean isHardwareEncoder() {
-+        return true;
++        return false;
 +    }
 +
 +}


### PR DESCRIPTION
## 変更内容

- SimulcastVideoEncoderFactory class の fallback に null を渡せるようにしました
  - 参照: simulcast_encoder_adapter 側では fallback_factory に null が渡されることは想定されているようです https://source.chromium.org/chromium/chromium/src/+/main:third_party/webrtc/media/engine/simulcast_encoder_adapter.h;l=47-48;drc=59947d28711f9ecec460e7ae83a769be5bd70794
    > // `fallback_factory`, if non-null, is used to create fallback encoder that
    > // will be used if InitEncode() fails for the primary encoder.

## 経緯

Sora Android SDK で利用している libwebrtc のバージョンを更新したところ、サイマルキャストがクラッシュすることを確認しました
この修正は、そのクラッシュを修正する過程で必要になりました