### PR TITLE
Android の HardwareVideoEncoder に実装された解像度の制限を回避するパッチを追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,12 @@
 VERSION ファイルを上げただけの場合は変更履歴記録は不要。
 パッチやビルドの変更のみ記録すること。
 
-## 96.4664.2.1
+## develop
+
+- [FIX] Android の HardwareVideoEncoder に実装された解像度の制限を回避するパッチを追加する
+    - @enm10k
+
+## m96.4664.2.1
 
 - [FIX] android_simulcast.patch を修正して、 SimulcastVideoEncoderFactory の fallback に null を渡せるようにする
     - @enm10k

--- a/patches/README.md
+++ b/patches/README.md
@@ -36,7 +36,9 @@ Android API に libwebrtc のビルド時のバージョンを取得する API �
 ## android_hardware_video_encoder.patch
 
 解像度が16の倍数でない場合、 HardwareVideoEncoder 初期化時などのチェックでエラーが発生するようになった。  
-Android CTS では解像度が16の倍数のケースしかテストされておらず、かつ実際に問題が発生する端末があったことが理由で、上記のチェックが実装された。
+Android CTS では解像度が16の倍数のケースしかテストされておらず、かつ、解像度が16の倍数でない映像を受信した際に問題が発生する端末があったことが理由で、上記のチェックが実装された。
+
+参照: https://webrtc-review.googlesource.com/c/src/+/229460
 
 このパッチでは、 Sora Android SDK 側でチェックを無効化する選択肢を提供するために、 libwebrtc に実装されたチェックを無効化している。  
 チェックを無効化するオプションがメインストリームに実装された場合、このパッチは削除できる。  

--- a/patches/README.md
+++ b/patches/README.md
@@ -12,7 +12,6 @@ Android にて映像フレームの処理時にクラッシュするいくつか
 
 同等の機能が本家に実装されるか、 PR を出して取り込まれたら削除する。
 
-
 ## android_simulcast.patch
 
 Android でのサイマルキャストのサポートを追加するパッチ。この実装は C++ の `SimulcastEncoderAdapter` の簡単なラッパーであり、既存の仕様に破壊的変更も行わない。
@@ -24,7 +23,6 @@ Android でのサイマルキャストのサポートを追加するパッチ。
 
 同等の機能が本家に実装されるか、 PR を出して取り込まれたら削除する。
 
- 
 ## android_webrtc_version.patch
 
 Android API に libwebrtc のビルド時のバージョンを取得する API を追加する。
@@ -35,6 +33,14 @@ Android API に libwebrtc のビルド時のバージョンを取得する API �
 
 同等の機能が本家に実装されるか、 PR を出して取り込まれたら削除する。
 
+## android_hardware_video_encoder.patch
+
+解像度が16の倍数でない場合、 HardwareVideoEncoder 初期化時などのチェックでエラーが発生するようになった。  
+Android CTS では解像度が16の倍数のケースしかテストされておらず、かつ実際に問題が発生する端末があったことが理由で、上記のチェックが実装された。
+
+このパッチでは、 Sora Android SDK 側でチェックを無効化する選択肢を提供するために、 libwebrtc に実装されたチェックを無効化している。  
+チェックを無効化するオプションがメインストリームに実装された場合、このパッチは削除できる。  
+https://bugs.chromium.org/p/webrtc/issues/detail?id=13973
 
 ## ios_bitcode.patch
 
@@ -47,7 +53,6 @@ iOS でのマイク不使用時のパーミッション要求を抑制するパ�
 
 同等の機能が本家に実装されるか PR を出して取り込まれたら削除するが、デフォルトの仕様の破壊的変更を含むので難しいと思われる。
 
-
 ## ios_simulcast.patch
 
 iOS でのサイマルキャストのサポートを追加するパッチ。この実装は C++ の `SimulcastEncoderAdapter` の簡単なラッパーであり、既存の仕様に破壊的変更も行わない。
@@ -58,7 +63,6 @@ iOS でのサイマルキャストのサポートを追加するパッチ。こ�
 - `RTCVideoEncoderSimulcast`
 
 同等の機能が本家に実装されるか、 PR を出して取り込まれたら削除する。
-
 
 ## macos_av1.patch
 

--- a/patches/android_hardware_video_encoder.patch
+++ b/patches/android_hardware_video_encoder.patch
@@ -1,0 +1,13 @@
+diff --git a/sdk/android/src/java/org/webrtc/HardwareVideoEncoder.java b/sdk/android/src/java/org/webrtc/HardwareVideoEncoder.java
+index e5062629c7..810935119e 100644
+--- a/sdk/android/src/java/org/webrtc/HardwareVideoEncoder.java
++++ b/sdk/android/src/java/org/webrtc/HardwareVideoEncoder.java
+@@ -55,7 +55,7 @@ class HardwareVideoEncoder implements VideoEncoder {
+   private static final int DEQUEUE_OUTPUT_BUFFER_TIMEOUT_US = 100000;
+ 
+   // Size of the input frames should be multiple of 16 for the H/W encoder.
+-  private static final int REQUIRED_RESOLUTION_ALIGNMENT = 16;
++  private static final int REQUIRED_RESOLUTION_ALIGNMENT = 1;
+ 
+   /**
+    * Keeps track of the number of output buffers that have been passed down the pipeline and not yet

--- a/run.py
+++ b/run.py
@@ -223,6 +223,7 @@ PATCHES = {
         'android_webrtc_version.patch',
         'android_fixsegv.patch',
         'android_simulcast.patch',
+        'android_hardware_video_encoder.patch',
     ],
     'raspberry-pi-os_armv6': [
         'nacl_armv6_2.patch',


### PR DESCRIPTION
## 変更内容

- Android の HardwareVideoEncoder に実装された解像度の制限を回避するパッチを追加しました