### PR TITLE
ios_proxy.patch を修正

### DIFF
--- a/patches/ios_proxy.patch
+++ b/patches/ios_proxy.patch
@@ -309,7 +309,7 @@ index 4e5aa19750..8b951d7d29 100644
 +    peerConnectionWithConfiguration:(RTC_OBJC_TYPE(RTCConfiguration) *)configuration
 +                        constraints:(RTC_OBJC_TYPE(RTCMediaConstraints) *)constraints
 +                certificateVerifier:
-+                    (id<RTC_OBJC_TYPE(RTCSSLCertificateVerifier)>)certificateVerifier
++                    (nullable id<RTC_OBJC_TYPE(RTCSSLCertificateVerifier)>)certificateVerifier
 +                           delegate:(nullable id<RTC_OBJC_TYPE(RTCPeerConnectionDelegate)>)delegate
 +                          proxyType:(RTCProxyType)proxyType
 +                         proxyAgent:(NSString*)proxyAgent

--- a/patches/ios_proxy.patch
+++ b/patches/ios_proxy.patch
@@ -190,7 +190,7 @@ index 88aac990f2..feca021d9a 100644
 +    peerConnectionWithConfiguration:(RTC_OBJC_TYPE(RTCConfiguration) *)configuration
 +                        constraints:(RTC_OBJC_TYPE(RTCMediaConstraints) *)constraints
 +                certificateVerifier:
-+                    (id<RTC_OBJC_TYPE(RTCSSLCertificateVerifier)>)certificateVerifier
++                    (nullable id<RTC_OBJC_TYPE(RTCSSLCertificateVerifier)>)certificateVerifier
 +                           delegate:(nullable id<RTC_OBJC_TYPE(RTCPeerConnectionDelegate)>)delegate
 +                          proxyType:(RTCProxyType)proxyType
 +                         proxyAgent:(NSString*)proxyAgent


### PR DESCRIPTION
## 変更内容

- プロキシを設定する API を Swift から利用しようとしたところ、certificateVerifier が必須になっていたので `nullable` を付与して optional にしました