### PR TITLE
JetPack 6.0 に対応するため ubuntu-22.04_armv8 のビルドを追加する

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,7 +102,7 @@ jobs:
           - ubuntu-20.04_x86_64
           - ubuntu-22.04_x86_64
           - android
-    runs-on: ${{ matrix.name == 'ubuntu-22.04_x86_64' && 'ubuntu-22.04' || 'ubuntu-20.04' }}
+    runs-on: ${{ startsWith(matrix.name, 'ubuntu-22.04') && 'ubuntu-22.04' || 'ubuntu-20.04' }}
     steps:
       - uses: actions/checkout@v4
       - name: Disk Cleanup

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,6 +98,7 @@ jobs:
           - raspberry-pi-os_armv8
           - ubuntu-18.04_armv8
           - ubuntu-20.04_armv8
+          - ubuntu-22.04_armv8
           - ubuntu-20.04_x86_64
           - ubuntu-22.04_x86_64
           - android
@@ -177,6 +178,9 @@ jobs:
       - uses: ./.github/actions/download
         with:
           platform: ubuntu-20.04_armv8
+      - uses: ./.github/actions/download
+        with:
+          platform: ubuntu-22.04_armv8
       - uses: ./.github/actions/download
         with:
           platform: ubuntu-20.04_x86_64

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -97,10 +97,11 @@ jobs:
           - raspberry-pi-os_armv8
           - ubuntu-18.04_armv8
           - ubuntu-20.04_armv8
+          - ubuntu-22.04_armv8
           - ubuntu-20.04_x86_64
           - ubuntu-22.04_x86_64
           - android
-    runs-on: ${{ matrix.name == 'ubuntu-22.04_x86_64' && 'ubuntu-22.04' || 'ubuntu-20.04' }}
+    runs-on: ${{ startsWith(matrix.name, 'ubuntu-22.04') && 'ubuntu-22.04' || 'ubuntu-20.04' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Please read https://github.com/shiguredo/oss/blob/master/README.en.md before use
   - Jetson AGX Xavier
   - Jetson Orin NX
   - Jetson AGX Orin
+- ubuntu-22.04_armv8 (動作未確認)
+  - Jetson AGX Orin
+  - Jetson Orin Nano
 - ubuntu-20.04_x86_64
 - ubuntu-22.04_x86_64
 - android_arm64

--- a/multistrap/ubuntu-22.04_armv8.conf
+++ b/multistrap/ubuntu-22.04_armv8.conf
@@ -1,0 +1,12 @@
+[General]
+noauth=true
+unpack=true
+bootstrap=Ports
+aptsources=Ports
+
+[Ports]
+packages=libc6-dev libstdc++-dev libasound2-dev libpulse-dev libudev-dev libexpat1-dev libnss3-dev python-dev-is-python3 libgtk-3-dev
+source=http://ports.ubuntu.com
+keyring=ubuntu-keyring
+suite=jammy
+components=main

--- a/run.py
+++ b/run.py
@@ -254,6 +254,12 @@ PATCHES = {
         'add_license_dav1d.patch',
         'ssl_verify_callback_with_native_handle.patch',
     ],
+    'ubuntu-22.04_armv8': [
+        'add_deps.patch',
+        '4k.patch',
+        'add_license_dav1d.patch',
+        'ssl_verify_callback_with_native_handle.patch',
+    ],
     'ubuntu-20.04_x86_64': [
         'add_deps.patch',
         '4k.patch',
@@ -370,6 +376,11 @@ MULTISTRAP_CONFIGS = {
     ),
     'ubuntu-20.04_armv8': MultistrapConfig(
         config_file=['multistrap', 'ubuntu-20.04_armv8.conf'],
+        arch='arm64',
+        triplet='aarch64-linux-gnu'
+    ),
+    'ubuntu-22.04_armv8': MultistrapConfig(
+        config_file=['multistrap', 'ubuntu-22.04_armv8.conf'],
         arch='arm64',
         triplet='aarch64-linux-gnu'
     ),
@@ -679,9 +690,10 @@ def build_webrtc(
                         'raspberry-pi-os_armv7',
                         'raspberry-pi-os_armv8',
                         'ubuntu-18.04_armv8',
-                        'ubuntu-20.04_armv8'):
+                        'ubuntu-20.04_armv8',
+                        'ubuntu-22.04_armv8'):
             sysroot = os.path.join(source_dir, 'rootfs')
-            arm64_set = ("raspberry-pi-os_armv8", "ubuntu-18.04_armv8", "ubuntu-20.04_armv8")
+            arm64_set = ("raspberry-pi-os_armv8", "ubuntu-18.04_armv8", "ubuntu-20.04_armv8", "ubuntu-22.04_armv8")
             gn_args += [
                 'target_os="linux"',
                 f'target_cpu="{"arm64" if target in arm64_set else "arm"}"',
@@ -917,6 +929,7 @@ TARGETS = [
     'ubuntu-22.04_x86_64',
     'ubuntu-18.04_armv8',
     'ubuntu-20.04_armv8',
+    'ubuntu-22.04_armv8',
     'raspberry-pi-os_armv6',
     'raspberry-pi-os_armv7',
     'raspberry-pi-os_armv8',
@@ -950,6 +963,7 @@ def check_target(target):
         # クロスコンパイルなので Ubuntu だったら任意のバージョンでビルド可能（なはず）
         if target in ('ubuntu-18.04_armv8',
                       'ubuntu-20.04_armv8',
+                      'ubuntu-22.04_armv8',
                       'raspberry-pi-os_armv6',
                       'raspberry-pi-os_armv7',
                       'raspberry-pi-os_armv8',


### PR DESCRIPTION
## 変更内容

JetPack 6.0 の対応として、 multistrap の設定を追加しました
(JetPack 6.0 から Jetson Linux が Ubuntu 22.04 ベースになります)

JetPack 6.0 は Developer Preview のため、動作は未確認としています

## 参照

[JetPack SDK 6.0 DP | NVIDIA Developer](https://developer.nvidia.com/embedded/jetpack-sdk-60dp)