### PR TITLE
oneVPL H265 対応

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@ VERSION ファイルを上げただけの場合は変更履歴記録は不要。
 
 ## master
 
-- [UPDATE] ubuntu-20.04_x86_64, ubuntu-22.04_x86_64 のビルド時に h265.patch を適用する
+- [UPDATE] ubuntu-20.04_x86_64, ubuntu-22.04_x86_64, windows_x86_64, windows_arm64 のビルドに h265.patch を適用する
   - @enm10k
 
 ## 122.6261.0.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,11 @@
 VERSION ファイルを上げただけの場合は変更履歴記録は不要。
 パッチやビルドの変更のみ記録すること。
 
+## master
+
+- [UPDATE] ubuntu-20.04_x86_64, ubuntu-22.04_x86_64 のビルド時に h265.patch を適用する
+  - @enm10k
+
 ## 122.6261.0.1
 
 - [FIX] リリース・バイナリを利用した Windows 向けのビルドが `error C3827: standard attribute 'deprecated' may have either no arguments or one string literal` というエラーになる問題を修正するパッチを追加する

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,9 +12,9 @@
 VERSION ファイルを上げただけの場合は変更履歴記録は不要。
 パッチやビルドの変更のみ記録すること。
 
-## master
+## 122.6261.0.2
 
-- [UPDATE] ubuntu-20.04_x86_64, ubuntu-22.04_x86_64, windows_x86_64, windows_arm64 のビルドに h265.patch を適用する
+- [UPDATE] ubuntu-20.04_x86_64, ubuntu-22.04_x86_64, windows_x86_64 のビルドに h265.patch を適用する
   - @enm10k
 
 ## 122.6261.0.1

--- a/patches/h265.patch
+++ b/patches/h265.patch
@@ -1144,7 +1144,7 @@ index 0000000000..5f53faab1a
 +
 +#endif  // MODULES_VIDEO_CODING_H265_SPS_PPS_TRACKER_H_
 diff --git a/modules/video_coding/include/video_codec_interface.h b/modules/video_coding/include/video_codec_interface.h
-index c6522fcc6b..de6e7ab981 100644
+index 987e1b623e..7a5cab75b0 100644
 --- a/modules/video_coding/include/video_codec_interface.h
 +++ b/modules/video_coding/include/video_codec_interface.h
 @@ -20,6 +20,9 @@
@@ -1157,9 +1157,9 @@ index c6522fcc6b..de6e7ab981 100644
  #include "modules/video_coding/codecs/vp9/include/vp9_globals.h"
  #include "modules/video_coding/include/video_error_codes.h"
  #include "rtc_base/system/rtc_export.h"
-@@ -90,10 +93,20 @@ struct CodecSpecificInfoH264 {
- };
- static_assert(std::is_pod<CodecSpecificInfoH264>::value, "");
+@@ -96,10 +99,20 @@ static_assert(std::is_trivial_v<CodecSpecificInfoH264> &&
+                   std::is_standard_layout_v<CodecSpecificInfoH264>,
+               "");
  
 +#ifdef RTC_ENABLE_H265
 +struct CodecSpecificInfoH265 {
@@ -1176,8 +1176,9 @@ index c6522fcc6b..de6e7ab981 100644
 +  CodecSpecificInfoH265 H265;
 +#endif
  };
- static_assert(std::is_pod<CodecSpecificInfoUnion>::value, "");
- 
+ static_assert(std::is_trivial_v<CodecSpecificInfoUnion> &&
+                   std::is_standard_layout_v<CodecSpecificInfoUnion>,
+               "");
 diff --git a/modules/video_coding/packet_buffer.cc b/modules/video_coding/packet_buffer.cc
 index 420a200ba9..635f90a748 100644
 --- a/modules/video_coding/packet_buffer.cc

--- a/run.py
+++ b/run.py
@@ -287,12 +287,14 @@ PATCHES = {
         "4k.patch",
         "add_license_dav1d.patch",
         "ssl_verify_callback_with_native_handle.patch",
+        "h265.patch",
     ],
     "ubuntu-22.04_x86_64": [
         "add_deps.patch",
         "4k.patch",
         "add_license_dav1d.patch",
         "ssl_verify_callback_with_native_handle.patch",
+        "h265.patch",
     ],
 }
 

--- a/run.py
+++ b/run.py
@@ -195,6 +195,7 @@ PATCHES = {
         "windows_fix_audio_device.patch",
         "ssl_verify_callback_with_native_handle.patch",
         "windows_fix_typo_in_deprecated_attribute.patch",
+        "h265.patch",
     ],
     "windows_arm64": [
         "4k.patch",


### PR DESCRIPTION
## 変更内容

oneVPL H265 対応 https://github.com/shiguredo-webrtc-build/webrtc-build/pull/67 を master ブランチに取り込むための PR です
上記の PR から必要なコミットを cherry-pick しています