### PR TITLE
windows-2022 を使うように修正

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         name:
           - windows_x86_64
           - windows_arm64
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.11

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -11,7 +11,7 @@ jobs:
         name:
           - windows_x86_64
           - windows_arm64
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
windows-2022 を使用するように変更しました。
CI は通っています。

すぐにマージせずマージタイミングを見てマージします