### PR TITLE
GitHub Actions の Android ビルド環境を Ubuntu 22.04 に上げる

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,7 +119,7 @@ jobs:
           - name: ubuntu-24.04_x86_64
             runs-on: ubuntu-24.04
           - name: android
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-22.04
     runs-on: ${{ matrix.platform.runs-on }}
     steps:
       - uses: actions/checkout@v4

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@ VERSION ファイルを上げただけの場合は変更履歴記録は不要。
 
 ## 2024-06-21
 
+- [UPDATE] GitHub Actions Android のビルド環境を Ubuntu 22.04 に上げる
+  - @zztkm
 - [ADD] Ubuntu 24.04 に対応
   - @melpon
 - [FIX] 生成した VERSIONS ファイルの指すコミットが shiguredo-patch パッチ適用後のコミットになっていたのを修正


### PR DESCRIPTION
変更内容

- [UPDATE] GitHub Actions Android のビルド環境を Ubuntu 22.04 に上げる

---

This pull request includes updates to the GitHub Actions build environment and documentation. The most important changes are the update of the Android build environment to Ubuntu 22.04 and the corresponding update in the `CHANGES.md` file.

Updates to the build environment:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L122-R122): Updated the Android build environment from Ubuntu 20.04 to Ubuntu 22.04.

Documentation updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R17-R18): Added a note about updating the GitHub Actions Android build environment to Ubuntu 22.04.
