### PR TITLE
GitHub Actions の Android ビルド環境を Ubuntu 22.04 に上げる

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,7 +119,7 @@ jobs:
           - name: ubuntu-24.04_x86_64
             runs-on: ubuntu-24.04
           - name: android
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-22.04
     runs-on: ${{ matrix.platform.runs-on }}
     steps:
       - uses: actions/checkout@v4

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,11 @@
 VERSION ファイルを上げただけの場合は変更履歴記録は不要。
 パッチやビルドの変更のみ記録すること。
 
+## 2024-08-19
+
+- [UPDATE] GitHub Actions Android のビルド環境を Ubuntu 22.04 に上げる
+  - @zztkm
+
 ## 2024-06-21
 
 - [ADD] Ubuntu 24.04 に対応


### PR DESCRIPTION
変更内容

- [UPDATE] GitHub Actions Android のビルド環境を Ubuntu 22.04 に上げる

---

This pull request includes updates to the GitHub Actions workflow and documentation. The most important changes include updating the build environment for the Android job and documenting this change in the `CHANGES.md` file.

Updates to GitHub Actions workflow:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L122-R122): Changed the `runs-on` version for the Android job from `ubuntu-20.04` to `ubuntu-22.04`.

Documentation updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R15-R19): Added an entry to document the update of the Android build environment to `ubuntu-22.04`.