### PR TITLE
[WIP] Sora iOS SDK 用に WebRTC.xcframework.zip をリリースバイナリに追加する

### DIFF
--- a/.github/actions/download/action.yml
+++ b/.github/actions/download/action.yml
@@ -30,3 +30,11 @@ runs:
       with:
         name: ${{ env.package_name }}
         path: ${{ env.package_name }}
+    # Sora iOS SDK 向けに WebRTC.xcframework.zip をダウンロードする
+    # ios のみ webrtc.${{ inputs.platform }}.tar.gz だけでなく
+    # WebRTC.xcframework.zip もダウンロードするために、このステップを追加している
+    - uses: actions/download-artifact@v4
+      if: inputs.platform == 'ios'
+      with:
+        name: WebRTC.xcframework.zip
+        path: WebRTC.xcframework.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,14 @@ jobs:
         with:
           name: webrtc.${{ matrix.platform.name }}.tar.gz
           path: _package/${{ matrix.platform.name }}/webrtc.${{ matrix.platform.name }}.tar.gz
+      # Sora iOS SDK 用に WebRTC.xcframework.zip をアップロードする
+      # ios のみ webrtc.${{ matrix.platform.name }}.tar.gz だけでなく、WebRTC.xcframework.zip もアップロードする
+      - name: Upload Artifact (for ios)
+        if: matrix.platform.name == 'ios'
+        uses: actions/upload-artifact@v4
+        with:
+          name: WebRTC.xcframework.zip
+          path: _package/${{ matrix.platform.name }}/WebRTC.xcframework.zip
   build-linux:
     strategy:
       fail-fast: false

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,8 @@ VERSION ファイルを上げただけの場合は変更履歴記録は不要。
 
 ## タイムライン
 
+- 2025-02-18 [UPDATE] Sora iOS SDK 用に WebRTC.xcframework.zip をリリースバイナリに追加する
+  - @zztkm
 - 2025-02-03 [UPDATE] m133 ブランチのビルドエラーに対する対応
   - build/config/compiler/BUILD.gn の変更に伴い、 macos_use_xcode_clang.patch を修正する
     - is_linux が実行条件の分岐が追加されていたため、macOS(is_mac) には不要であるため削除した

--- a/run.py
+++ b/run.py
@@ -1311,6 +1311,20 @@ def package_webrtc(
                 for file in enum_all_files("webrtc", "."):
                     f.add(name=file, arcname=file)
 
+    # target が ios のときに WebRTC.xcframework を zip 化
+    if target == "ios":
+        frameworks_dir = os.path.join(package_dir, "webrtc", "Frameworks")
+        with cd(frameworks_dir):
+            with zipfile.ZipFile("WebRTC.xcframework.zip", "w", zipfile.ZIP_DEFLATED) as zipf:
+                for root, _, files in os.walk("WebRTC.xcframework"):
+                    for file in files:
+                        file_path = os.path.join(root, file)
+                        arcname = os.path.relpath(file_path, start=frameworks_dir)
+                        zipf.write(file_path, arcname)
+        # WebRTC.xcframework.zip を package_dir に移動
+        xcframework_zip_path = os.path.join(frameworks_dir, "WebRTC.xcframework.zip")
+        shutil.move(xcframework_zip_path, os.path.join(package_dir, "WebRTC.xcframework.zip"))
+
 
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 TARGETS = [


### PR DESCRIPTION
- [UPDATE] Sora iOS SDK 用に WebRTC.xcframework.zip をリリースバイナリに追加する


