### PR TITLE
ubuntu-20.04_x86_64 を削除して CI で Ubuntu 20.04 を利用しないようにする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,19 +109,17 @@ jobs:
       matrix:
         platform:
           - name: raspberry-pi-os_armv6
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-22.04
           - name: raspberry-pi-os_armv7
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-22.04
           - name: raspberry-pi-os_armv8
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-22.04
           - name: ubuntu-20.04_armv8
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-22.04
           - name: ubuntu-22.04_armv8
             runs-on: ubuntu-22.04
           - name: ubuntu-24.04_armv8
             runs-on: ubuntu-24.04
-          - name: ubuntu-20.04_x86_64
-            runs-on: ubuntu-20.04
           - name: ubuntu-22.04_x86_64
             runs-on: ubuntu-22.04
           - name: ubuntu-24.04_x86_64
@@ -188,7 +186,7 @@ jobs:
       - build-windows
       - build-macos
       - build-linux
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/download
@@ -221,9 +219,6 @@ jobs:
       - uses: ./.github/actions/download
         with:
           platform: ubuntu-24.04_armv8
-      - uses: ./.github/actions/download
-        with:
-          platform: ubuntu-20.04_x86_64
       - uses: ./.github/actions/download
         with:
           platform: ubuntu-22.04_x86_64

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,15 @@ VERSION ファイルを上げただけの場合は変更履歴記録は不要。
 
 ## タイムライン
 
+- 2025-04-07 [CHANGE] リリース対象から ubuntu-20.04_x86_64 を削除する
+  - @miosakuma
+- 2025-04-07 [UPDATE] Github Actions のビルド実行環境を Ubuntu 20.04 から Ubuntu 22.04 にあげる
+  - 対象のビルドターゲットは以下の通り
+    - ubuntu-20.04_armv8
+    - raspberry-pi-os_armv6
+    - raspberry-pi-os_armv7
+    - raspberry-pi-os_armv8
+  - @miosakuma
 - 2025-04-03 [RELEASE] m135.7049.2.1
   - @miosakuma
 - 2025-04-02 [RELEASE] m134.6998.1.1

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -10,7 +10,7 @@
 python3 run.py build <target>
 ```
 
-`<target>` の部分には、`windows` や `ubuntu-20.04_x86_64` 等のターゲット名が入る。
+`<target>` の部分には、`windows` や `ubuntu-22.04_x86_64` 等のターゲット名が入る。
 
 詳細は `python3 run.py --help` や `python3 run.py build --help` 等を参照すること。
 
@@ -62,14 +62,14 @@ iOS の `WebRTC.xcframework`、Android の `webrtc.aar` は、他の場合と変
 ```
 webrtc-build/
 |-- _source/
-|   |-- ubuntu-20.04_x86_64/
+|   |-- ubuntu-22.04_x86_64/
 |   |   |-- depot_tools/...
 |   |   `-- webrtc/...
 |   `-- android/
 |       |-- depot_tools/...
 |       `-- webrtc/...
 `-- _build/
-    |-- ubuntu-20.04_x86_64/
+    |-- ubuntu-22.04_x86_64/
     |   |-- debug/
     |   |   `-- webrtc/...
     |   `-- release/
@@ -102,7 +102,6 @@ webrtc-build/
 - macOS の場合は `macos_x86_64`, `macos_arm64`, `ios` ターゲットのみビルド可能。
 - Ubuntu の x86_64 環境の場合、上記以外のターゲットのみビルド可能。
   - `android`, `raspberry-pi-os_armv*`, `ubuntu-*_armv8` あたりの ARM 環境は Ubuntu のバージョンに関係なくビルド可能
-  - `ubuntu-20.04_x86_64` の場合は Ubuntu 20.04 が必要
   - `ubuntu-22.04_x86_64` の場合は Ubuntu 22.04 が必要
   - `ubuntu-24.04_x86_64` の場合は Ubuntu 24.04 が必要
 - Ubuntu の x86_64 でない環境ではビルド不可能。

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ Please read <https://github.com/shiguredo/oss/blob/master/README.en.md> before u
 - ubuntu-22.04_armv8
   - Jetson AGX Orin
   - Jetson Orin Nano
-- ubuntu-20.04_x86_64
 - ubuntu-22.04_x86_64
 - ubuntu-24.04_armv8
 - ubuntu-24.04_x86_64

--- a/run.py
+++ b/run.py
@@ -337,17 +337,6 @@ PATCHES = {
         "fix_moved_function_call.patch",
         "remove_crel.patch",
     ],
-    "ubuntu-20.04_x86_64": [
-        "add_deps.patch",
-        "4k.patch",
-        "revive_proxy.patch",
-        "add_license_dav1d.patch",
-        "ssl_verify_callback_with_native_handle.patch",
-        "h265.patch",
-        "fix_perfetto.patch",
-        "fix_moved_function_call.patch",
-        "remove_crel.patch",
-    ],
     "ubuntu-22.04_x86_64": [
         "add_deps.patch",
         "4k.patch",
@@ -1035,7 +1024,7 @@ def build_webrtc(
                     "arm_use_neon=false",
                     "enable_libaom=false",
                 ]
-        elif target in ("ubuntu-20.04_x86_64", "ubuntu-22.04_x86_64", "ubuntu-24.04_x86_64"):
+        elif target in ("ubuntu-22.04_x86_64", "ubuntu-24.04_x86_64"):
             gn_args += [
                 'target_os="linux"',
                 "rtc_use_pipewire=false",
@@ -1347,7 +1336,6 @@ TARGETS = [
     "windows_x86_64",
     "windows_arm64",
     "macos_arm64",
-    "ubuntu-20.04_x86_64",
     "ubuntu-22.04_x86_64",
     "ubuntu-24.04_x86_64",
     "ubuntu-20.04_armv8",
@@ -1398,8 +1386,6 @@ def check_target(target):
         # x86_64 用ビルドはバージョンが合っている必要がある
         osver = release["VERSION_ID"]
         logging.info(f"OS Version: {osver}")
-        if target == "ubuntu-20.04_x86_64" and osver == "20.04":
-            return True
         if target == "ubuntu-22.04_x86_64" and osver == "22.04":
             return True
         if target == "ubuntu-24.04_x86_64" and osver == "24.04":


### PR DESCRIPTION
Github Actions で Ubuntu 20.04 が対象外となるため、
リリース対象から ubuntu-20.04_x86_64 を削除して、Ubuntu 20.04 でビルドしていたバイナリを Ubuntu 22.04 にあげました。

Ubuntu 24.04 ではなく、Ubuntu 22.04 にしたのは Android とあわせて、今後は一括で対応できるようにするためですが、
「合わせる必要はないので 24.04 にしてはどうか」「ついでに Android も含めて 24.04 にしてはどうか」などご意見ありましたらお願いします。

- 2025-04-07 [CHANGE] リリース対象から ubuntu-20.04_x86_64 を削除する
- 2025-04-07 [UPDATE] Github Actions のビルド実行環境を Ubuntu 20.04 から Ubuntu 22.04 にあげる
  - 対象のビルドターゲットは以下の通り
    - ubuntu-20.04_armv8
    - raspberry-pi-os_armv6
    - raspberry-pi-os_armv7
    - raspberry-pi-os_armv8

---
This pull request includes several changes primarily focused on updating the build environments from Ubuntu 20.04 to Ubuntu 22.04 and removing references to the `ubuntu-20.04_x86_64` target. The changes affect various configuration files, documentation, and scripts.

Changes to build configurations:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L112-L124): Updated the `runs-on` parameter for multiple build targets from `ubuntu-20.04` to `ubuntu-22.04`, and removed the `ubuntu-20.04_x86_64` target. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L112-L124) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L191-R189) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L224-L226)

Documentation updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R32-R40): Added entries to reflect the removal of `ubuntu-20.04_x86_64` and the update of build environments to Ubuntu 22.04.
* [`DEVELOPMENT.md`](diffhunk://#diff-fc2a310fcfedfefb0046def697f932def80cbb1e78c689bc0af3c8eab3e33eceL13-R13): Updated references from `ubuntu-20.04_x86_64` to `ubuntu-22.04_x86_64` in various sections. [[1]](diffhunk://#diff-fc2a310fcfedfefb0046def697f932def80cbb1e78c689bc0af3c8eab3e33eceL13-R13) [[2]](diffhunk://#diff-fc2a310fcfedfefb0046def697f932def80cbb1e78c689bc0af3c8eab3e33eceL65-R72) [[3]](diffhunk://#diff-fc2a310fcfedfefb0046def697f932def80cbb1e78c689bc0af3c8eab3e33eceL105)
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L47): Removed the `ubuntu-20.04_x86_64` entry from the list of supported platforms.

Script modifications:

* [`run.py`](diffhunk://#diff-d6af0459a37d985953d7040c14f53feb3b9cc9e58b543aa3c2b80256d276c5e0L340-L350): Removed the `ubuntu-20.04_x86_64` target from various functions and configurations. [[1]](diffhunk://#diff-d6af0459a37d985953d7040c14f53feb3b9cc9e58b543aa3c2b80256d276c5e0L340-L350) [[2]](diffhunk://#diff-d6af0459a37d985953d7040c14f53feb3b9cc9e58b543aa3c2b80256d276c5e0L1038-R1027) [[3]](diffhunk://#diff-d6af0459a37d985953d7040c14f53feb3b9cc9e58b543aa3c2b80256d276c5e0L1350) [[4]](diffhunk://#diff-d6af0459a37d985953d7040c14f53feb3b9cc9e58b543aa3c2b80256d276c5e0L1401-L1402)