### PR TITLE
android_sdk ビルドから armeabi-v7a 向けのバイナリを削除する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,8 @@ VERSION ファイルを上げただけの場合は変更履歴記録は不要。
 
 ## タイムライン
 
+- 2025-09-11 [CHANGE] android_sdk ビルドから armeabi-v7a 向けのバイナリを削除する
+  - @melpon
 - 2025-09-05 [CHANGE] raspberry-pi-os_armv6 と raspberry-pi-os_armv7 を削除する
   - @torikizi
 - 2025-09-02 [UPDATE] macOS GitHub Actions の `build-macos` から Ninja をインストールするステップを削除する

--- a/run.py
+++ b/run.py
@@ -904,7 +904,7 @@ def build_webrtc_ios_sdk(
 
 
 ANDROID_ARCHS = ["arm64-v8a"]
-ANDROID_SDK_ARCHS = ["armeabi-v7a", "arm64-v8a"]
+ANDROID_SDK_ARCHS = ["arm64-v8a"]
 ANDROID_TARGET_CPU = {
     "armeabi-v7a": "arm",
     "arm64-v8a": "arm64",


### PR DESCRIPTION
ビルド時間を減らすために削除してみました。