### PR TITLE
m152 のビルドエラーに対するパッチを更新する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,8 +31,8 @@ VERSION ファイルを上げただけの場合は変更履歴記録は不要。
 
 - 2026-07-31 [UPDATE] m152 ブランチのビルドエラーに対する対応
   - ios_simulcast.patch を m152 の変更に対応する
-    - m152 で `rtc_media_base` ビルドターゲットが削除されたため、`simulcast` ターゲットの deps を個別ターゲットの列挙に置き換える
-    - 置き換えにあたり追加した deps は、`rtc_media_base` の deps に含まれていた以下の 2 つ
+    - m152 で `rtc_media_base` ターゲットが削除されたため、ios_simulcast.patch で使用する deps を定義する
+    - 必要な deps は、`rtc_media_base` の deps に含まれていた以下のとおり
       - `../api/video_codecs:scalability_mode`: `api/video_codecs/scalability_mode.h`
       - `../api/video_codecs:video_codecs_api`: `api/video_codecs/video_codec.h` と `api/video_codecs/sdp_video_format.h`
     - 参考: https://source.chromium.org/chromium/_/webrtc/src/+/91dbc17ae49f9fbf2071b5d60bf1b823973c4a4f

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,7 +31,10 @@ VERSION ファイルを上げただけの場合は変更履歴記録は不要。
 
 - 2026-07-31 [UPDATE] m152 ブランチのビルドエラーに対する対応
   - ios_simulcast.patch を m152 の変更に対応する
-    - m152 で `rtc_media_base` ビルドターゲットが削除されたため、`simulcast` ターゲットの deps を具体的なターゲットに置き換える
+    - m152 で `rtc_media_base` ビルドターゲットが削除されたため、`simulcast` ターゲットの deps を個別ターゲットの列挙に置き換える
+    - 置き換えにあたり追加した deps は、`rtc_media_base` の deps に含まれていた以下の 2 つ
+      - `../api/video_codecs:scalability_mode`: `api/video_codecs/scalability_mode.h`
+      - `../api/video_codecs:video_codecs_api`: `api/video_codecs/video_codec.h` と `api/video_codecs/sdp_video_format.h`
     - 参考: https://source.chromium.org/chromium/_/webrtc/src/+/91dbc17ae49f9fbf2071b5d60bf1b823973c4a4f
   - windows_add_deps.patch のコンテキストを m152 の BUILD.gn に合わせる
     - m152 で `stats` deps が削除されたため

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,16 @@ VERSION ファイルを上げただけの場合は変更履歴記録は不要。
 
 ## タイムライン
 
+- 2026-07-31 [UPDATE] m152 ブランチのビルドエラーに対する対応
+  - ios_simulcast.patch を m152 の変更に対応する
+    - m152 で `rtc_media_base` ビルドターゲットが削除されたため、`simulcast` ターゲットの deps を具体的なターゲットに置き換える
+    - 参考: https://source.chromium.org/chromium/_/webrtc/src/+/91dbc17ae49f9fbf2071b5d60bf1b823973c4a4f
+  - windows_add_deps.patch のコンテキストを m152 の BUILD.gn に合わせる
+    - m152 で `stats` deps が削除されたため
+    - 参考: https://source.chromium.org/chromium/_/webrtc/src/+/cd7885ddf46e657672db275706a54b5da4c9db6b
+  - add_deps.patch のコンテキストを m152 の BUILD.gn に合わせる
+    - m152 で `pc:libjingle_peerconnection` deps が削除されたため
+  - @torikizi
 - 2026-07-17 [RELEASE] m150.7871.3.1
   - @t-miya
 - 2026-07-16 [UPDATE] ARM 向け sysroot 生成を独自実装へ移行する

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,10 +36,10 @@ VERSION ファイルを上げただけの場合は変更履歴記録は不要。
       - `../api/video_codecs:scalability_mode`: `api/video_codecs/scalability_mode.h`
       - `../api/video_codecs:video_codecs_api`: `api/video_codecs/video_codec.h` と `api/video_codecs/sdp_video_format.h`
     - 参考: https://source.chromium.org/chromium/_/webrtc/src/+/91dbc17ae49f9fbf2071b5d60bf1b823973c4a4f
-  - windows_add_deps.patch のコンテキストを m152 の BUILD.gn に合わせる
+  - windows_add_deps.patch のパッチのずれを修正する
     - m152 で `stats` deps が削除されたため
     - 参考: https://source.chromium.org/chromium/_/webrtc/src/+/cd7885ddf46e657672db275706a54b5da4c9db6b
-  - add_deps.patch のコンテキストを m152 の BUILD.gn に合わせる
+  - add_deps.patch のパッチのずれを修正する
     - m152 で `pc:libjingle_peerconnection` deps が削除されたため
   - @torikizi
 - 2026-07-17 [RELEASE] m150.7871.3.1

--- a/patches/add_deps.patch
+++ b/patches/add_deps.patch
@@ -1,10 +1,10 @@
 diff --git a/BUILD.gn b/BUILD.gn
-index 40ac574218..1342e932b9 100644
+index 442d5f212f..49ccdfcd21 100644
 --- a/BUILD.gn
 +++ b/BUILD.gn
-@@ -555,6 +555,11 @@ if (!build_with_chromium) {
-       "pc:libjingle_peerconnection",
+@@ -578,6 +578,11 @@ if (!build_with_chromium) {
        "pc:rtc_pc",
+       "pc:webrtc_sdp",
        "video",
 +      "//third_party/zlib",
 +      "rtc_base:log_sinks",

--- a/patches/add_deps.patch
+++ b/patches/add_deps.patch
@@ -2,7 +2,7 @@ diff --git a/BUILD.gn b/BUILD.gn
 index 442d5f212f..49ccdfcd21 100644
 --- a/BUILD.gn
 +++ b/BUILD.gn
-@@ -578,6 +578,11 @@ if (!build_with_chromium) {
+@@ -578,6 +578,12 @@ if (!build_with_chromium) {
        "pc:rtc_pc",
        "pc:webrtc_sdp",
        "video",

--- a/patches/ios_simulcast.patch
+++ b/patches/ios_simulcast.patch
@@ -30,7 +30,7 @@ index 1a7fd8e3f6..03a7f586c3 100644
          ":base_native_additions_objc",
          ":base_objc",
          ":helpers_objc",
-@@ -769,6 +764,22 @@ if (is_ios || is_mac) {
+@@ -769,6 +764,32 @@ if (is_ios || is_mac) {
        }
      }
  
@@ -45,8 +45,18 @@ index 1a7fd8e3f6..03a7f586c3 100644
 +      deps = [
 +        ":base_objc",
 +        ":wrapped_native_codec_objc",
-+        "../media:rtc_media_base",
++        ":native_api",
++        ":videocodec_objc",
++        "../api/video_codecs:scalability_mode",
++        "../api/video_codecs:video_codecs_api",
++        "../media:media_constants",
 +        "../media:rtc_simulcast_encoder_adapter",
++        "../modules/video_coding:webrtc_h264",
++        "../modules/video_coding:webrtc_vp8",
++        "../modules/video_coding:webrtc_vp8_scalability",
++        "../modules/video_coding:webrtc_vp9",
++        "../modules/video_coding/codecs/av1:av1_svc_config",
++        "//third_party/abseil-cpp/absl/container:inlined_vector",
 +      ]
 +    }
 +

--- a/patches/ios_simulcast.patch
+++ b/patches/ios_simulcast.patch
@@ -30,7 +30,7 @@ index 1a7fd8e3f6..03a7f586c3 100644
          ":base_native_additions_objc",
          ":base_objc",
          ":helpers_objc",
-@@ -769,6 +764,32 @@ if (is_ios || is_mac) {
+@@ -769,6 +764,23 @@ if (is_ios || is_mac) {
        }
      }
  
@@ -45,18 +45,9 @@ index 1a7fd8e3f6..03a7f586c3 100644
 +      deps = [
 +        ":base_objc",
 +        ":wrapped_native_codec_objc",
-+        ":native_api",
-+        ":videocodec_objc",
 +        "../api/video_codecs:scalability_mode",
 +        "../api/video_codecs:video_codecs_api",
-+        "../media:media_constants",
 +        "../media:rtc_simulcast_encoder_adapter",
-+        "../modules/video_coding:webrtc_h264",
-+        "../modules/video_coding:webrtc_vp8",
-+        "../modules/video_coding:webrtc_vp8_scalability",
-+        "../modules/video_coding:webrtc_vp9",
-+        "../modules/video_coding/codecs/av1:av1_svc_config",
-+        "//third_party/abseil-cpp/absl/container:inlined_vector",
 +      ]
 +    }
 +

--- a/patches/windows_add_deps.patch
+++ b/patches/windows_add_deps.patch
@@ -2,12 +2,11 @@ diff --git a/BUILD.gn b/BUILD.gn
 index 3b1c52b6ad..87e4c1f479 100644
 --- a/BUILD.gn
 +++ b/BUILD.gn
-@@ -564,8 +564,13 @@ if (!build_with_chromium) {
-      "pc:peer_connection_factory",
-      "pc:rtc_pc",
-      "pc:webrtc_sdp",
-      "stats",
-      "video",
+@@ -577,7 +577,12 @@ if (!build_with_chromium) {
+       "pc:peer_connection_factory",
+       "pc:rtc_pc",
+       "pc:webrtc_sdp",
+       "video",
 +      "modules/audio_device:audio_device_module_from_input_and_output",
 +      "//third_party/zlib",
 +      "rtc_base:log_sinks",

--- a/patches/windows_add_deps.patch
+++ b/patches/windows_add_deps.patch
@@ -2,7 +2,7 @@ diff --git a/BUILD.gn b/BUILD.gn
 index 3b1c52b6ad..87e4c1f479 100644
 --- a/BUILD.gn
 +++ b/BUILD.gn
-@@ -577,7 +577,12 @@ if (!build_with_chromium) {
+@@ -577,7 +577,13 @@ if (!build_with_chromium) {
        "pc:peer_connection_factory",
        "pc:rtc_pc",
        "pc:webrtc_sdp",


### PR DESCRIPTION
- ios_simulcast.patch の rtc_media_base 依存を具体的なターゲットに置き換える
- windows_add_deps.patch と add_deps.patch のコンテキストを m152 に合わせる